### PR TITLE
Install zod in the api project

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -10,7 +10,8 @@
             "license": "ISC",
             "dependencies": {
                 "@prisma/client": "^5.10.2",
-                "fastify": "^4.26.1"
+                "fastify": "^4.26.1",
+                "zod": "^3.22.4"
             },
             "devDependencies": {
                 "@tsconfig/node20": "^20.1.2",
@@ -1900,6 +1901,14 @@
             "dev": true,
             "engines": {
                 "node": ">= 14"
+            }
+        },
+        "node_modules/zod": {
+            "version": "3.22.4",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+            "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
             }
         }
     }

--- a/api/package.json
+++ b/api/package.json
@@ -24,7 +24,8 @@
     "homepage": "https://github.com/Somehow-I-Code/marquei#readme",
     "dependencies": {
         "@prisma/client": "^5.10.2",
-        "fastify": "^4.26.1"
+        "fastify": "^4.26.1",
+        "zod": "^3.22.4"
     },
     "devDependencies": {
         "@tsconfig/node20": "^20.1.2",


### PR DESCRIPTION
O pacote do zod não se encontra nas dependências do projeto.

Um dos motivos pra que o projeto esteja funcionando mesmo sem ele estar corretamente instalado é pelo fato dele estar presente no nosso node_modules daquele aula de discussão de backend que a gente teve.

Se a pasta for removida, o projeto para de funcionar.

Precisamos refazer a instalação do pacote.