### PR TITLE
Tratar as respostas de sucesso e fracasso no login

### DIFF
--- a/web/src/app/login/components/login-form.tsx
+++ b/web/src/app/login/components/login-form.tsx
@@ -10,9 +10,11 @@ import {
     FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { useToast } from "@/components/ui/use-toast";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Eye, EyeOff } from "lucide-react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
@@ -33,6 +35,8 @@ type LoginFormProps = {
 };
 
 export default function LoginForm({ login }: LoginFormProps) {
+    const { toast } = useToast();
+    const router = useRouter();
     const form = useForm<LoginFormSchema>({
         resolver: zodResolver(FormSchema),
         defaultValues: {
@@ -44,7 +48,19 @@ export default function LoginForm({ login }: LoginFormProps) {
     const [showPassword, setShowPassword] = useState(false);
 
     async function onSubmit(credentials: LoginFormSchema) {
-        const token = await login(credentials);
+        try {
+            const token = await login(credentials);
+            localStorage.setItem("marqueitoken", token);
+            router.push("/");
+        } catch (e) {
+            if (e instanceof Error) {
+                toast({
+                    variant: "destructive",
+                    title: "Algo não deu certo!",
+                    description: e.message,
+                });
+            }
+        }
     }
 
     return (

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -11,6 +11,12 @@ export default function LoginPage() {
                 "content-type": "application/json",
             },
         });
+
+        if (response.status !== 200) {
+            const data = (await response.json()) as { message: string };
+            throw new Error(data.message);
+        }
+
         const data = (await response.json()) as { token: string };
         return data.token;
     }


### PR DESCRIPTION
Esse PR trata as respostas de sucesso e fracasso do login.

Caso o status da resposta seja 200 (Sucesso) será gerado um token para autenticar o usuário, o token é salvo no navegador e o usuário e redirecionado para a tela home.

Se o o status da resposta for diferente de 200, será lançado um toast na tela apresentando um erro para o usuário. 

Toast com a mensagem de erro:

![Captura de tela 2024-05-17 103202](https://github.com/Somehow-I-Code/marquei/assets/129136093/e9c3668b-54ee-4061-a929-6c030b822728)
