### PR TITLE
SCRUM-127 envia senhas auto geradas no slack

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -4,6 +4,9 @@
 # Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server, MongoDB and CockroachDB.
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 
+# Endereço pra acessar o banco de dados de dentro dos containers docker
 DATABASE_URL=
-# Requisitar ao Thiago JWT_SECRET
+# Qualquer string pra poder criar os tokens (não interferem em produção)
 JWT_SECRET=
+# Requisitar url do hook para o Thiago
+SLACK_HOOK_PASSWORDS=

--- a/api/src/repositories/profiles.ts
+++ b/api/src/repositories/profiles.ts
@@ -9,7 +9,7 @@ class ProfileRepository {
         const password = generatePassword();
         const passwordHash = await hash(password, 10);
 
-        emailService.sendEmailWithPassword(password);
+        emailService.sendEmailWithPassword(email, password);
 
         const profile = await prisma.profile.create({
             data: {

--- a/api/src/services/email.ts
+++ b/api/src/services/email.ts
@@ -1,5 +1,19 @@
 class EmailService {
-    sendEmailWithPassword(password: string) {
+    sendEmailWithPassword(email: string, password: string) {
+        const slackHookUrl = process.env.SLACK_HOOK_PASSWORDS;
+
+        if (typeof slackHookUrl === "string") {
+            fetch(slackHookUrl, {
+                method: "POST",
+                body: JSON.stringify({
+                    text: `Novos email e senha gerados ${email} ${password}`,
+                }),
+                headers: {
+                    "content-type": "application/json",
+                },
+            });
+        }
+
         console.log(`Pra logar na plataforma use a senha: ${password}`);
     }
 }


### PR DESCRIPTION
# Envio de senhas auto geradas par ao slack

## Qual problema esse pull request resolve?
Quando um novo usuário é criado, a senha é mostrada apenas no terminal do vscode. Se o terminal for atualizado, a gente acaba perdendo acesso a essa senha e precisamos de um novo usuário pois é impossível logar sem a senha.

Esse pull request adiciona a habilidade de enviar as senhas no slack, assim temos acesso ao usuário com a senha bastando procurar no canal correspondente no slack.

## Como o seu código resolve esse problema?
Eu faço uma requisição para um endpoint do slack de um app criado por mim com o fim de automatizar mensagens do slack.

![image](https://github.com/Somehow-I-Code/marquei/assets/8589984/4a6cba7c-b356-4fee-af04-87640eae4e6d)

Esse endpoint roda apenas um `fetch` normal com algumas informações necessárias pro hook. Quando esse endpoint é chamado, o slack automaticamente manda uma mensagem pra mim no slack com o texto que eu forneci.

Eu mantive a mensagem no terminal como um fallback pra caso o slack tenha algum problema em enviar a mensagem.

## Quais os passos para testar essa feature/bug?
- Requisite o endereço do web hook do slack para o @goislimat 
- Crie a chave `SLACK_HOOK_PASSWORDS` no seu arquivo `.env` e coloque o endereço do web hook como seu valor
- Pode ser que você precise reiniciar os containers pois houve uma mudança no arquivo `.env`
- Crie um novo perfil usando o Postman ou o form de novo perfil
- A mensagem deve chegar no canal #generated-passwords do slack

**Obs:** As senhas vão parar no nosso canal, mas elas somente servem para quem as criou. Exemplo, um usuário criado por mim vai notificar o canal com a senha gerada, mas apenas eu, na minha máquina, vou conseguir fazer o login com essas credenciais. O mesmo serve pra qualquer outra pessoa.