### PR TITLE
Create reset password token

### DIFF
--- a/api/src/http/routes/login.ts
+++ b/api/src/http/routes/login.ts
@@ -1,6 +1,7 @@
 import bcrypt from "bcrypt";
 import { FastifyInstance } from "fastify";
 import jwt from "jsonwebtoken";
+import z from "zod";
 import profileRepository from "../../repositories/profiles";
 import { LoginInput, loginSchema } from "../../validators/login-form";
 
@@ -19,7 +20,7 @@ export async function login(server: FastifyInstance) {
         } catch (error) {
             return reply.code(400).send({
                 error: "ValidationError",
-                message: (error as Error).message,
+                message: (error as z.ZodError).issues[0].message,
             });
         }
 
@@ -44,3 +45,4 @@ export async function login(server: FastifyInstance) {
         return reply.code(200).send({ token });
     });
 }
+

--- a/api/src/http/routes/reset-password.ts
+++ b/api/src/http/routes/reset-password.ts
@@ -1,5 +1,6 @@
 import { FastifyInstance } from "fastify";
 import jwt from "jsonwebtoken";
+import z from "zod";
 import profileRepository from "../../repositories/profiles";
 import {
     ResetPassword,
@@ -21,9 +22,10 @@ export async function resetPassword(server: FastifyInstance) {
         try {
             resetPasswordEmail = resetPasswordSchema.parse(request.body);
         } catch (e) {
+            console.log(e);
             return reply.code(400).send({
-                e: "E-mail Inválido",
-                message: (e as Error).message,
+                error: "ValidationError",
+                message: (e as z.ZodError).issues[0].message,
             });
         }
 

--- a/api/src/http/routes/reset-password.ts
+++ b/api/src/http/routes/reset-password.ts
@@ -18,7 +18,14 @@ export async function resetPassword(server: FastifyInstance) {
 
         let resetPasswordEmail: ResetPassword;
 
-        resetPasswordEmail = resetPasswordSchema.parse(request.body);
+        try {
+            resetPasswordEmail = resetPasswordSchema.parse(request.body);
+        } catch (e) {
+            return reply.code(400).send({
+                e: "E-mail Inválido",
+                message: (e as Error).message,
+            });
+        }
 
         const { email } = resetPasswordEmail;
 
@@ -36,6 +43,7 @@ export async function resetPassword(server: FastifyInstance) {
             },
             process.env.JWT_SECRET,
         );
-        return reply.code(200).send({ token });
+        return reply.status(200).send({ token });
     });
 }
+

--- a/api/src/http/routes/reset-password.ts
+++ b/api/src/http/routes/reset-password.ts
@@ -1,24 +1,41 @@
 import { FastifyInstance } from "fastify";
+import jwt from "jsonwebtoken";
 import profileRepository from "../../repositories/profiles";
 import {
     ResetPassword,
     resetPasswordSchema,
 } from "../../validators/reset-password";
 
+const _1_HOUR = 1000 * 60 * 60;
+
 export async function resetPassword(server: FastifyInstance) {
     server.post("/reset-password", async (request, reply) => {
+        if (process.env.JWT_SECRET === undefined) {
+            return reply
+                .status(500)
+                .send({ message: "JWT SECRET não configurado" });
+        }
+
         let resetPasswordEmail: ResetPassword;
 
         resetPasswordEmail = resetPasswordSchema.parse(request.body);
 
         const { email } = resetPasswordEmail;
 
-        const user = await profileRepository.findByEmail(email);
+        const profile = await profileRepository.findByEmail(email);
 
-        if (!user) {
-            return reply.status(404).send({ error: "Email não encontrado" });
+        if (!profile) {
+            return reply.status(404).send({ message: "Email não encontrado" });
         }
+
+        const token = jwt.sign(
+            {
+                id: profile.id,
+                email: profile.email,
+                expiresAt: Date.now() + _1_HOUR,
+            },
+            process.env.JWT_SECRET,
+        );
+        return reply.code(200).send({ token });
     });
 }
-
-

--- a/api/src/validators/login-form.ts
+++ b/api/src/validators/login-form.ts
@@ -1,8 +1,9 @@
 import z from "zod";
 
 export const loginSchema = z.object({
-    email: z.string().email(),
-    password: z.string().min(8),
+    email: z.string().email("E-mail inválido"),
+    password: z.string().min(8, "Senha deve ter no mínimo 8 caracteres"),
 });
 
 export type LoginInput = z.infer<typeof loginSchema>;
+

--- a/api/src/validators/reset-password.ts
+++ b/api/src/validators/reset-password.ts
@@ -1,7 +1,8 @@
 import z from "zod";
 
 export const resetPasswordSchema = z.object({
-    email: z.string().email(),
+    email: z.string().email("E-mail inválido"),
 });
 
-export type ResetPassword = z.infer<typeof resetPasswordSchema>
+export type ResetPassword = z.infer<typeof resetPasswordSchema>;
+


### PR DESCRIPTION

# Criar token para reset de senha

## Qual problema esse pull request resolve?
Esse PR cria o token de reset de senha, esse token será único para cada usuário que solicitar o reset e irá servir como um link para que o usuário acesse a tela onde será criada a nova senha. 

O link será: `http://localhost:3001/password-reset/[token]`

No lugar de `[token]` será o token gerado.

## Como o seu código resolve esse problema?

Foi adicionado um `if` que verifica se a `JWT_SECRET` está definida no arquivo `.env`, se a `JWT_SECRET` não estiver definida será retornado um erro de status (500) com a mensagem "JWT SECRET não configurado".

Se a a `JWT_SECRET` estiver configurada corretamente será gerado um token usando o id e e-mail do usuário. O token também terá um campo `expiresAt` que define em quanto tempo o token gerado irá expirar, para esse caso cada token irá expirar em 1 hora.

## Quais os passos para testar essa feature/bug?

- Rodar a aplicação
- Mandar uma requisição para a url `http://localhost:8080/reset-password` colocando no corpo da requisição o e-mail de algum usuário que exista no banco de dados
- Copiar o token gerado
![Captura de tela 2024-06-19 003319](https://github.com/Somehow-I-Code/marquei/assets/129136093/0f0b9f97-1488-49dc-b7e2-4ec8ee9d41a7)
- Acessar `https://jwt.io`
- Colando o token no campo encoded é possível ver o id e e-mail do usuário, a data de expiração do token que está em milissegundos e a data de criação do token que também estará representa em milissegundos.
![Captura de tela 2024-06-19 004334](https://github.com/Somehow-I-Code/marquei/assets/129136093/2a7d1532-abcf-4cd9-8213-5d0c195d35d4)
