### PR TITLE
Fazendo onsubmit e envio de DB.

### DIFF
--- a/api/src/http/routes/change-password.ts
+++ b/api/src/http/routes/change-password.ts
@@ -69,7 +69,5 @@ export async function changePassword(server: FastifyInstance) {
         }
 
         await profileRepository.updatePassword(profile.id, newPassword);
-
-        return reply.status(200).send();
     });
 }

--- a/api/src/http/routes/change-password.ts
+++ b/api/src/http/routes/change-password.ts
@@ -69,5 +69,9 @@ export async function changePassword(server: FastifyInstance) {
         }
 
         await profileRepository.updatePassword(profile.id, newPassword);
+
+        return reply
+            .status(200)
+            .send({ message: "Senha alterada com sucesso" });
     });
 }

--- a/api/src/http/routes/change-password.ts
+++ b/api/src/http/routes/change-password.ts
@@ -70,8 +70,6 @@ export async function changePassword(server: FastifyInstance) {
 
         await profileRepository.updatePassword(profile.id, newPassword);
 
-        return reply
-            .status(200)
-            .send({ message: "Senha alterada com sucesso" });
+        return reply.status(200).send();
     });
 }

--- a/web/src/app/change-password/components/change-password-form.tsx
+++ b/web/src/app/change-password/components/change-password-form.tsx
@@ -21,13 +21,13 @@ import { z } from "zod";
 
 const FormSchema = z.object({
     currentPassword: z.string().min(8, {
-        message: "A senha atual deve conter no mínimo 8 caracteres",
+        message: "A senha atual deve conter no mínimo 8 letras ou números",
     }),
     newPassword: z.string().min(8, {
-        message: "A senha nova deve conter no mínimo 8 caracteres",
+        message: "A senha nova deve conter no mínimo 8 letras ou números",
     }),
     repeatPassword: z.string().min(8, {
-        message: "A senha repetida deve conter no mínimo 8 caracteres",
+        message: "A senha repetida deve conter no mínimo 8 letras ou números",
     }),
 });
 

--- a/web/src/app/change-password/components/change-password-form.tsx
+++ b/web/src/app/change-password/components/change-password-form.tsx
@@ -9,39 +9,48 @@ import {
     FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { ToastAction } from "@/components/ui/toast";
+import { useToast } from "@/components/ui/use-toast";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Eye, EyeOff } from "lucide-react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
 const FormSchema = z.object({
-    oldPassword: z.string().min(8, {
-        message: "Sua senha deve conter no mínimo 8 caracteres",
+    currentPassword: z.string().min(8, {
+        message: "A senha atual deve conter no mínimo 8 caracteres",
     }),
     newPassword: z.string().min(8, {
-        message: "Sua senha deve conter no mínimo 8 caracteres",
+        message: "A senha nova deve conter no mínimo 8 caracteres",
     }),
     repeatPassword: z.string().min(8, {
-        message: "Sua senha deve conter no mínimo 8 caracteres",
+        message: "A senha repetida deve conter no mínimo 8 caracteres",
     }),
 });
 
 export type ChangePasswordFormSchema = z.infer<typeof FormSchema>;
 
-export default function ChangePasswordForm() {
+type ChangePasswordFormProps = {
+    changePassword: (data: ChangePasswordFormSchema) => void;
+};
+
+export default function ChangePasswordForm({
+    changePassword,
+}: ChangePasswordFormProps) {
     const form = useForm<ChangePasswordFormSchema>({
         resolver: zodResolver(FormSchema),
         defaultValues: {
-            oldPassword: "",
+            currentPassword: "",
             newPassword: "",
             repeatPassword: "",
         },
     });
 
     const [showPassword, setShowPassword] = useState({
-        oldPassword: false,
+        currentPassword: false,
         newPassword: false,
         repeatPassword: false,
     });
@@ -53,7 +62,38 @@ export default function ChangePasswordForm() {
         });
     };
 
-    function onSubmit(data: ChangePasswordFormSchema) {}
+    const { toast } = useToast();
+
+    const router = useRouter();
+
+    async function onSubmit(data: ChangePasswordFormSchema) {
+        try {
+            await changePassword(data);
+
+            form.reset();
+
+            toast({
+                title: "Ótimo!",
+                description: "Senha alterada com sucesso",
+                action: (
+                    <ToastAction
+                        onClick={() => router.push("/profile")}
+                        altText="Ir para o perfil"
+                    >
+                        Ir para o perfil
+                    </ToastAction>
+                ),
+            });
+        } catch (e) {
+            if (e instanceof Error) {
+                toast({
+                    variant: "destructive",
+                    title: "Algo não deu certo!",
+                    description: e.message,
+                });
+            }
+        }
+    }
 
     return (
         <Form {...form}>
@@ -63,30 +103,32 @@ export default function ChangePasswordForm() {
             >
                 <FormField
                     control={form.control}
-                    name="oldPassword"
+                    name="currentPassword"
                     render={({ field }) => (
                         <FormItem className="flex flex-col">
                             <FormLabel>Senha antiga</FormLabel>
                             <FormControl>
                                 <div className="flex justify-between items-center">
                                     <Input
-                                        id="oldPassword"
+                                        id="currentPassword"
                                         type={
-                                            showPassword.oldPassword
+                                            showPassword.currentPassword
                                                 ? "text"
                                                 : "password"
                                         }
-                                        placeholder="Digite sua senha antiga"
+                                        placeholder="Digite sua senha atual"
                                         {...field}
                                     />
                                     <button
                                         type="button"
                                         onClick={() =>
-                                            passwordVisibility("oldPassword")
+                                            passwordVisibility(
+                                                "currentPassword",
+                                            )
                                         }
                                         className="absolute right-8"
                                     >
-                                        {showPassword.oldPassword ? (
+                                        {showPassword.currentPassword ? (
                                             <EyeOff size={20} />
                                         ) : (
                                             <Eye size={20} />
@@ -152,7 +194,7 @@ export default function ChangePasswordForm() {
                                                 ? "text"
                                                 : "password"
                                         }
-                                        placeholder="Digite sua nova senha"
+                                        placeholder="Repita sua nova senha"
                                         {...field}
                                     />
                                     <button

--- a/web/src/app/change-password/page.tsx
+++ b/web/src/app/change-password/page.tsx
@@ -28,18 +28,13 @@ export default async function ChangePasswordPage() {
 
         const body = {
             ...data,
-            currentPassword: String(data.currentPassword),
-            newPassword: String(data.newPassword),
-            repeatPassword: String(data.repeatPassword),
         };
-
-        const token = `Bearer ${session}`;
 
         const response = await fetch("http://api:8080/change-password", {
             method: "PATCH",
             headers: {
                 "content-type": "application/json",
-                authorization: token,
+                authorization: `Bearer ${session}`,
             },
             body: JSON.stringify(body),
         });

--- a/web/src/app/change-password/page.tsx
+++ b/web/src/app/change-password/page.tsx
@@ -3,6 +3,18 @@ import CompanyLogo from "../components/company-logo";
 import ChangePasswordForm, {
     ChangePasswordFormSchema,
 } from "./components/change-password-form";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
+function getSession() {
+    const session = cookies().get("session")?.value;
+
+    if (!session) {
+        return null;
+    }
+
+    return session;
+}
 
 export default async function ChangePasswordPage() {
     async function changePassword(data: ChangePasswordFormSchema) {
@@ -15,14 +27,16 @@ export default async function ChangePasswordPage() {
             repeatPassword: String(data.repeatPassword),
         };
 
-        const token =
-            "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZW1haWwiOiJ1c2VyZGFzaWx2YUBlbWFpbC5jb20iLCJsZXZlbCI6IkFETUlOIiwiY29tcGFueUlkIjoxLCJpYXQiOjE3MTk4NjM0ODF9.1GCkjQ3RmOOvI12VnHZLd-d1MkhVW7wrsQ51kd0e0Hw";
+        const session = getSession();
+
+        if (!session) {
+            return redirect("/profile");
+        }
 
         const response = await fetch("http://api:8080/change-password", {
             method: "PATCH",
             headers: {
                 "content-type": "application/json",
-                authorization: token,
             },
             body: JSON.stringify(body),
         });

--- a/web/src/app/change-password/page.tsx
+++ b/web/src/app/change-password/page.tsx
@@ -1,7 +1,40 @@
+import { revalidatePath } from "next/cache";
 import CompanyLogo from "../components/company-logo";
-import ChangePasswordForm from "./components/change-password-form";
+import ChangePasswordForm, {
+    ChangePasswordFormSchema,
+} from "./components/change-password-form";
 
 export default async function ChangePasswordPage() {
+    async function changePassword(data: ChangePasswordFormSchema) {
+        "use server";
+
+        const body = {
+            ...data,
+            currentPassword: String(data.currentPassword),
+            newPassword: String(data.newPassword),
+            repeatPassword: String(data.repeatPassword),
+        };
+
+        const token =
+            "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZW1haWwiOiJ1c2VyZGFzaWx2YUBlbWFpbC5jb20iLCJsZXZlbCI6IkFETUlOIiwiY29tcGFueUlkIjoxLCJpYXQiOjE3MTk4NjM0ODF9.1GCkjQ3RmOOvI12VnHZLd-d1MkhVW7wrsQ51kd0e0Hw";
+
+        const response = await fetch("http://api:8080/change-password", {
+            method: "PATCH",
+            headers: {
+                "content-type": "application/json",
+                authorization: token,
+            },
+            body: JSON.stringify(body),
+        });
+
+        if (response.status !== 200) {
+            const data = (await response.json()) as { message: string };
+            throw new Error(data.message);
+        }
+
+        revalidatePath("/profile");
+    }
+
     return (
         <section>
             <div className="h-40 px-6 py-12">
@@ -13,7 +46,7 @@ export default async function ChangePasswordPage() {
                     Alterar sua senha
                 </h1>
 
-                <ChangePasswordForm />
+                <ChangePasswordForm changePassword={changePassword} />
             </div>
         </section>
     );

--- a/web/src/app/change-password/page.tsx
+++ b/web/src/app/change-password/page.tsx
@@ -17,6 +17,12 @@ function getSession() {
 }
 
 export default async function ChangePasswordPage() {
+    const session = getSession();
+
+    if (!session) {
+        return redirect("/login");
+    }
+
     async function changePassword(data: ChangePasswordFormSchema) {
         "use server";
 
@@ -27,16 +33,13 @@ export default async function ChangePasswordPage() {
             repeatPassword: String(data.repeatPassword),
         };
 
-        const session = getSession();
-
-        if (!session) {
-            return redirect("/profile");
-        }
+        const token = `Bearer ${session}`;
 
         const response = await fetch("http://api:8080/change-password", {
             method: "PATCH",
             headers: {
                 "content-type": "application/json",
+                authorization: token,
             },
             body: JSON.stringify(body),
         });


### PR DESCRIPTION
# Envio para banco de dados a alteração de senha e mensagens de sucesso e erro

## Qual problema esse pull request resolve?
Inicialmente, é necessário que o usuário esteja autenticado para poder criar uma nova senha. Ao usar esta funcionalidade, o usuário deve inserir sua senha antiga e, em seguida, criar uma nova senha e confirmá-la. Depois, as informações serão enviadas para o banco de dados para verificação e atualização da senha. Assim, uma mensagem de sucesso ou de erro será retornada.

## Como o seu código resolve esse problema?
- O token de autenticação é colado manualmente para permitir a alteração da senha e é íncluído o "authorization" no cabeçalho da requisição.
- Usa o fetch para enviar as informações para banco de dados (O endpoint change-password).
- O componente toast é usado para mostrar uma mensagem de sucesso e redirecionar o usuário para página de perfil. O mesmo componente é utilizado para retornar mesangens de erro.

## Quais os passos para testar essa feature/bug?
- No terminal digite **`make run`**
- Cole o token gerado na sua máquina no caminho `...app/change-password/page.tsx.`
- Abra o navegador e acesse `http://localhost:3001/change-password` para realizar teste.

Prints de testes:
1. Mensagem de "Senha alterada com sucesso":
![image](https://github.com/Somehow-I-Code/marquei/assets/133810168/7194d54b-5f01-4f22-82dd-95f450377534)

2. Mensagem de "Senha atual incorreta":
![image](https://github.com/Somehow-I-Code/marquei/assets/133810168/96e65c7d-4789-403f-a590-6f44b6967230)

3. Mensagem de A nova senha não pode ser igual à antiga senha":
![image](https://github.com/Somehow-I-Code/marquei/assets/133810168/6c91aff4-d33c-4d7c-99b6-c5aa83a621cf)

4. Mensagem de "Nova senha e repetida devem ser iguais":
![image](https://github.com/Somehow-I-Code/marquei/assets/133810168/5ddffbd0-2ebe-41cb-9852-5e2401a72249)

