### PR TITLE
Criado pasta utils de arquivo getToken

### DIFF
--- a/api/src/http/routes/change-password.ts
+++ b/api/src/http/routes/change-password.ts
@@ -1,16 +1,11 @@
 import bcrypt from "bcrypt";
 import { FastifyInstance } from "fastify";
-import { IncomingHttpHeaders } from "http";
 import jwt from "jsonwebtoken";
 import { ZodError } from "zod";
 import profileRepository from "../../repositories/profiles";
 import { changePasswordSchema } from "../../validators/change-password";
 import { ChangePasswordInput } from "./../../validators/change-password";
-
-function getToken(headers: IncomingHttpHeaders) {
-    const requestAuthorization = headers["authorization"];
-    return requestAuthorization?.split(" ")[1];
-}
+import { getToken } from "../routes/utils/get-token";
 
 export async function changePassword(server: FastifyInstance) {
     server.patch("/change-password", async (request, reply) => {

--- a/api/src/http/routes/create-profile.ts
+++ b/api/src/http/routes/create-profile.ts
@@ -1,15 +1,9 @@
 import { Level } from "@prisma/client";
 import { FastifyInstance } from "fastify";
-import { IncomingHttpHeaders } from "http";
 import { verify } from "jsonwebtoken";
 import profileRepository from "../../repositories/profiles";
 import { createProfileSchema } from "../../validators/profile";
-
-function getToken(headers: IncomingHttpHeaders) {
-    const { authorization } = headers;
-
-    return authorization?.split(" ")[1];
-}
+import { getToken } from "../routes/utils/get-token";
 
 export async function createProfile(server: FastifyInstance) {
     server.post("/profiles", async (request, reply) => {

--- a/api/src/http/routes/get-levels.ts
+++ b/api/src/http/routes/get-levels.ts
@@ -1,12 +1,7 @@
 import { Level } from "@prisma/client";
 import { FastifyInstance } from "fastify";
-import { IncomingHttpHeaders } from "http";
 import { verify } from "jsonwebtoken";
-
-function getToken(headers: IncomingHttpHeaders) {
-    const { authorization } = headers;
-    return authorization?.split(" ")[1];
-}
+import { getToken } from "../routes/utils/get-token";
 
 function removeSudoFromLevels(levels: Array<string>) {
     return levels.filter((level) => level !== Level.SUDO);
@@ -14,9 +9,9 @@ function removeSudoFromLevels(levels: Array<string>) {
 
 export async function getLevels(server: FastifyInstance) {
     server.get("/levels", async (request, reply) => {
-        const token = getToken(request.headers);
+        const levelToken = getToken(request.headers);
 
-        if (!token) {
+        if (!levelToken) {
             return reply.status(400).send({ message: "Token inválido" });
         }
 
@@ -26,7 +21,7 @@ export async function getLevels(server: FastifyInstance) {
                 .send({ message: "JWT SECRET não configurado" });
         }
 
-        const profile = verify(token, process.env.JWT_SECRET) as {
+        const profile = verify(levelToken, process.env.JWT_SECRET) as {
             level: Level;
         };
 

--- a/api/src/http/routes/get-profile.ts
+++ b/api/src/http/routes/get-profile.ts
@@ -1,25 +1,24 @@
 import { FastifyInstance } from "fastify";
 import jwt from "jsonwebtoken";
 import profileRepository from "../../repositories/profiles";
+import { getToken } from "./utils/get-token";
 
 export async function getProfile(server: FastifyInstance) {
     server.get("/profile", async (request, reply) => {
+        const profileToken = getToken(request.headers);
+
         if (typeof process.env.JWT_SECRET !== "string") {
             return reply
                 .status(500)
                 .send({ message: "Configuração de token não aplicada" });
         }
 
-        const requestAuthorization = request.headers["authorization"];
-
-        const token = requestAuthorization?.split(" ")[1];
-
-        if (!token) {
+        if (!profileToken) {
             //TODO: Adicionar isso ao middleware de autorização
             return reply.send({ message: "Falta token na requisição" });
         }
 
-        const decoded = jwt.verify(token, process.env.JWT_SECRET) as {
+        const decoded = jwt.verify(profileToken, process.env.JWT_SECRET) as {
             id: number;
         };
 

--- a/api/src/http/routes/sudo-login.ts
+++ b/api/src/http/routes/sudo-login.ts
@@ -1,16 +1,10 @@
 import { Level } from "@prisma/client";
 import { FastifyInstance } from "fastify";
-import { IncomingHttpHeaders } from "http";
 import { sign, verify } from "jsonwebtoken";
 import { ZodError } from "zod";
 import profileRepository from "../../repositories/profiles";
 import { SudoLoginInput, sudoLoginSchema } from "../../validators/sudo-login";
-
-function getToken(headers: IncomingHttpHeaders) {
-    const { authorization } = headers;
-
-    return authorization?.split(" ")[1];
-}
+import { getToken } from "./utils/get-token";
 
 export async function sudoLogin(server: FastifyInstance) {
     server.post("/sudo-login", async (request, reply) => {

--- a/api/src/http/routes/utils/get-token.ts
+++ b/api/src/http/routes/utils/get-token.ts
@@ -1,0 +1,6 @@
+import { IncomingHttpHeaders } from "http";
+
+export function getToken(headers: IncomingHttpHeaders) {
+    const requestAuthorization = headers["authorization"];
+    return requestAuthorization?.split(" ")[1];
+}


### PR DESCRIPTION
#TIRANDO DUPLICAÇÕES DE **GETTOKEN**

## Qual problema esse pull request resolve?
Existem vários arquivos que utilizam a mesma função **_getToken_** para buscar o token do cabeçalho da requisição). Para resolver isso, a função foi centralizada em um único arquivo.


## Como o seu código resolve esse problema?
A função **_getToken_** foi centralizada em um único arquivo para facilitar a reutilização do código. Em vez de duplicar a lógica de busca do token em diferentes partes do projeto, todos os arquivos agora podem importar essa função de um único local.

## Quais os passos para testar essa feature/bug?
- No terminal digite `make run`
- Utilize o **Rest Client** para enviar uma requisição que utilize a função getToken e verifique se o token está sendo gerado corretamente.

**Prints de testes:**

Busca de perfil:
![image](https://github.com/user-attachments/assets/5852ca1d-41b5-4b82-99e3-5ab25cdb34a3)

Login:
![image](https://github.com/user-attachments/assets/b1510ae6-f877-4743-a740-5111ea4e87f8)


