### PR TITLE
Criando o layout da tela de cadastrar empresa

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13,6 +13,7 @@
                 "@radix-ui/react-label": "^2.0.2",
                 "@radix-ui/react-select": "^2.0.0",
                 "@radix-ui/react-slot": "^1.0.2",
+                "@radix-ui/react-switch": "^1.1.0",
                 "@radix-ui/react-toast": "^1.1.5",
                 "class-variance-authority": "^0.7.0",
                 "clsx": "^2.1.0",
@@ -2952,6 +2953,182 @@
             "peerDependencies": {
                 "@types/react": "*",
                 "react": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-switch": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.1.0.tgz",
+            "integrity": "sha512-OBzy5WAj641k0AOSpKQtreDMe+isX0MQJ1IVyF03ucdF3DunOnROVrjWs8zsXUxC3zfZ6JL9HFVCUlMghz9dJw==",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.0",
+                "@radix-ui/react-compose-refs": "1.1.0",
+                "@radix-ui/react-context": "1.1.0",
+                "@radix-ui/react-primitive": "2.0.0",
+                "@radix-ui/react-use-controllable-state": "1.1.0",
+                "@radix-ui/react-use-previous": "1.1.0",
+                "@radix-ui/react-use-size": "1.1.0"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/primitive": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.0.tgz",
+            "integrity": "sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA=="
+        },
+        "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-compose-refs": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.0.tgz",
+            "integrity": "sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw==",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-context": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.0.tgz",
+            "integrity": "sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A==",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-primitive": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.0.tgz",
+            "integrity": "sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==",
+            "dependencies": {
+                "@radix-ui/react-slot": "1.1.0"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-slot": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.0.tgz",
+            "integrity": "sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==",
+            "dependencies": {
+                "@radix-ui/react-compose-refs": "1.1.0"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-use-callback-ref": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
+            "integrity": "sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-use-controllable-state": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.1.0.tgz",
+            "integrity": "sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==",
+            "dependencies": {
+                "@radix-ui/react-use-callback-ref": "1.1.0"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-use-layout-effect": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz",
+            "integrity": "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-use-previous": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.0.tgz",
+            "integrity": "sha512-Z/e78qg2YFnnXcW88A4JmTtm4ADckLno6F7OXotmkQfeuCVaKuYzqAATPhVzl3delXE7CxIV8shofPn3jPc5Og==",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-use-size": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.0.tgz",
+            "integrity": "sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==",
+            "dependencies": {
+                "@radix-ui/react-use-layout-effect": "1.1.0"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
             },
             "peerDependenciesMeta": {
                 "@types/react": {

--- a/web/package.json
+++ b/web/package.json
@@ -18,6 +18,7 @@
         "@radix-ui/react-label": "^2.0.2",
         "@radix-ui/react-select": "^2.0.0",
         "@radix-ui/react-slot": "^1.0.2",
+        "@radix-ui/react-switch": "^1.1.0",
         "@radix-ui/react-toast": "^1.1.5",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",

--- a/web/src/app/new-company/components/new-company-form.tsx
+++ b/web/src/app/new-company/components/new-company-form.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormLabel,
+    FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import { zodResolver } from "@hookform/resolvers/zod";
+import Link from "next/link";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+
+const FormSchema = z.object({
+    name: z.string().min(1, {
+        message: "O nome da empresa não pode estar vazio",
+    }),
+    isActive: z.boolean().default(false),
+});
+
+export type NewCompanyFormSchema = z.infer<typeof FormSchema>;
+
+export default function NewCompanyForm() {
+    const form = useForm<NewCompanyFormSchema>({
+        resolver: zodResolver(FormSchema),
+        defaultValues: {
+            name: "",
+            isActive: false,
+        },
+    });
+
+    return (
+        <Form {...form}>
+            <form className="flex flex-col gap-6">
+                <div className="flex flex-col gap-4">
+                    <FormField
+                        control={form.control}
+                        name="name"
+                        render={({ field }) => (
+                            <FormItem>
+                                <div className="flex flex-col gap-2">
+                                    <FormLabel htmlFor="name">Nome</FormLabel>
+                                    <FormControl>
+                                        <Input
+                                            id="name"
+                                            type="text"
+                                            placeholder="Gisele SPA das Unhas..."
+                                            {...field}
+                                        />
+                                    </FormControl>
+                                </div>
+                                <FormMessage />
+                            </FormItem>
+                        )}
+                    />
+
+                    <FormField
+                        control={form.control}
+                        name="isActive"
+                        render={({ field }) => (
+                            <FormItem>
+                                <div className="flex justify-between">
+                                    <FormLabel>Está ativo?</FormLabel>
+
+                                    <FormControl>
+                                        <Switch />
+                                    </FormControl>
+                                </div>
+                            </FormItem>
+                        )}
+                    />
+                </div>
+
+                <div className="flex flex-col gap-2">
+                    <Button className="bg-indigo-950 font-bold">SALVAR</Button>
+
+                    <Button
+                        asChild
+                        variant="outline"
+                        className="border border-indigo-950 text-indigo-950 font-bold"
+                    >
+                        <Link href="/">CANCELAR</Link>
+                    </Button>
+                </div>
+            </form>
+        </Form>
+    );
+}

--- a/web/src/app/new-company/page.tsx
+++ b/web/src/app/new-company/page.tsx
@@ -1,0 +1,19 @@
+import CompanyLogo from "../components/company-logo";
+import FormTitle from "../components/form-title";
+import NewCompanyForm from "./components/new-company-form";
+
+export default async function NewCompany() {
+    return (
+        <section>
+            <div className="h-40 px-6 py-12">
+                <CompanyLogo />
+            </div>
+
+            <div className="p-6 flex flex-col gap-8">
+                <FormTitle>Criar uma empresa</FormTitle>
+
+                <NewCompanyForm />
+            </div>
+        </section>
+    );
+}

--- a/web/src/app/new-profile/components/new-profile-form.tsx
+++ b/web/src/app/new-profile/components/new-profile-form.tsx
@@ -238,7 +238,7 @@ export default function NewProfileForm({
                     <Button
                         asChild
                         variant="outline"
-                        className="border border-indigo-950 font-bold"
+                        className="border border-indigo-950 text-indigo-950 font-bold"
                     >
                         <Link href="/">CANCELAR</Link>
                     </Button>

--- a/web/src/app/new-resource/components/newResourceForm.tsx
+++ b/web/src/app/new-resource/components/newResourceForm.tsx
@@ -201,7 +201,7 @@ export default function NewResourceForm({
                     <Button
                         asChild
                         variant="outline"
-                        className="border border-indigo-950 font-bold"
+                        className="border border-indigo-950 text-indigo-950 font-bold"
                     >
                         <Link href="/">CANCELAR</Link>
                     </Button>

--- a/web/src/components/ui/switch.tsx
+++ b/web/src/components/ui/switch.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import * as SwitchPrimitives from "@radix-ui/react-switch";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Switch = React.forwardRef<
+    React.ElementRef<typeof SwitchPrimitives.Root>,
+    React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+    <SwitchPrimitives.Root
+        className={cn(
+            "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-indigo-950 data-[state=unchecked]:bg-input",
+            className,
+        )}
+        {...props}
+        ref={ref}
+    >
+        <SwitchPrimitives.Thumb
+            className={cn(
+                "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0",
+            )}
+        />
+    </SwitchPrimitives.Root>
+));
+Switch.displayName = SwitchPrimitives.Root.displayName;
+
+export { Switch };


### PR DESCRIPTION
# Criando o layout da tela de cadastrar empresa

## Qual problema esse pull request resolve?
Mostra a tela com o formulário que permitirá o cadastro de uma empresa, através da rota `http://localhost:3001/new-company`.
Este PR contém, apenas, o layout da tela cadastrar empresa. Não contém a lógica, ou seja, não faz o envio do form, e os botões não funcionam, esta parte será implementada em um outro PR. Estou fazendo esta separação para que a revisão fique mais fácil e rápida.


## Como o seu código resolve esse problema?
Utilizei como referência o layout "Criar uma empresa" desenhado no figma.
Na web foi criado a rota `new-company`. Esta rota contém o componente `new-company-form` no qual tem o formulário solicitando os dados necessários para criar uma empresa.
O componente `new-company-form` é chamado dentro de page. tsx, no qual contém o restante do layout da página (logo do projeto e título da tela).
Apenas relembrando, este PR não tem implementado a lógica do form e nem faz o envio dos dados pro DB, o foco aqui é apenas ver em tela os campos do form.


## Quais os passos para testar essa feature/bug?

1.  Rode o container principal: `make run`;
2.  Na barra de endereço do navegador, digite o endereço: `http://localhost:3001/new-company`;

Segue print da tela:
![image](https://github.com/user-attachments/assets/20888eb0-01e7-42a7-9122-edc6b02d93cb)

