### PR TITLE
Criando rota de new company

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -2,6 +2,7 @@ import Fastify from "fastify";
 import { adminCreateProfile } from "./src/http/routes/admin-create-profile";
 import { changePassword } from "./src/http/routes/change-password";
 import { createCategories } from "./src/http/routes/create-categories";
+import { createCompany } from "./src/http/routes/create-company";
 import { createProfile } from "./src/http/routes/create-profile";
 import { createResources } from "./src/http/routes/create-resources";
 import { getCategories } from "./src/http/routes/get-categories";
@@ -30,6 +31,7 @@ server.register(resetPassword);
 server.register(adminCreateProfile);
 server.register(changePassword);
 server.register(sudoLogin);
+server.register(createCompany);
 
 server.listen({ port: 8080, host: "0.0.0.0" }, (err, address) => {
     if (err) {

--- a/api/requests/company/create-company.http
+++ b/api/requests/company/create-company.http
@@ -1,0 +1,21 @@
+# @name login
+POST {{host}}/login
+Content-Type: application/json
+
+{
+    "email": "sudoGisele01@email.com",
+    "password": "12345678"
+}
+
+###
+
+@authToken = Bearer {{login.response.body.$.token}}
+
+POST {{host}}/company
+Content-Type: application/json
+Authorization: {{authToken}}
+
+{
+    "name": "Gisele SPA das unhas",
+    "isActive": true
+}

--- a/api/src/http/routes/create-categories.ts
+++ b/api/src/http/routes/create-categories.ts
@@ -5,10 +5,11 @@ import { createCategory } from "../../validators/categories";
 
 export async function createCategories(server: FastifyInstance) {
     server.post("/categories", async (request, reply) => {
-        const { title } = createCategory.parse(request.body);
+        const { title, companyId } = createCategory.parse(request.body);
 
         const category = await categoriesRepository.create({
             title,
+            companyId,
         });
 
         return reply.status(201).send(category);

--- a/api/src/http/routes/create-company.ts
+++ b/api/src/http/routes/create-company.ts
@@ -1,0 +1,16 @@
+import { FastifyInstance } from "fastify";
+import companyRepository from "../../repositories/company";
+import { createCompanySchema } from "./../../validators/company";
+
+export async function createCompany(server: FastifyInstance) {
+    server.post("/company", async (request, reply) => {
+        const { name, isActive } = createCompanySchema.parse(request.body);
+
+        const company = await companyRepository.create({
+            name,
+            isActive,
+        });
+
+        return reply.status(201).send(company);
+    });
+}

--- a/api/src/repositories/categories.ts
+++ b/api/src/repositories/categories.ts
@@ -2,11 +2,11 @@ import { prisma } from "../lib/prisma";
 import { CreateCategoryInput } from "../validators/categories";
 
 class CategoriesRepository {
-    async create({ title }: CreateCategoryInput) {
+    async create({ title, companyId }: CreateCategoryInput) {
         const category = await prisma.category.create({
             data: {
                 title,
-                companyId: 1,
+                companyId,
             },
         });
 

--- a/api/src/repositories/company.ts
+++ b/api/src/repositories/company.ts
@@ -1,0 +1,18 @@
+import { prisma } from "../lib/prisma";
+import { CreateCompanyInput } from "../validators/company";
+
+class CompanyRepository {
+    async create({ name, isActive }: CreateCompanyInput) {
+        const company = await prisma.company.create({
+            data: {
+                name,
+                isActive,
+            },
+        });
+
+        return company;
+    }
+}
+
+const companyRepository = new CompanyRepository();
+export default companyRepository;

--- a/api/src/repositories/resources.ts
+++ b/api/src/repositories/resources.ts
@@ -2,13 +2,18 @@ import { prisma } from "../lib/prisma";
 import { CreateResourceInput } from "./../validators/resources";
 
 class ResourcesRepository {
-    async create({ name, description, categoryId }: CreateResourceInput) {
+    async create({
+        name,
+        description,
+        categoryId,
+        companyId,
+    }: CreateResourceInput) {
         const resource = await prisma.resource.create({
             data: {
                 name,
                 description,
                 categoryId,
-                companyId: 1,
+                companyId,
             },
         });
 

--- a/api/src/validators/categories.ts
+++ b/api/src/validators/categories.ts
@@ -1,7 +1,14 @@
 import { z } from "zod";
 
 export const createCategory = z.object({
-    title: z.string(),
+    title: z.string({
+        required_error: "Nome da categoria é obrigatório!",
+        invalid_type_error: "Nome da categoria é obrigatório!",
+    }),
+    companyId: z.number({
+        required_error: "Empresa é obrigatório, contate o suporte!",
+        invalid_type_error: "Empresa é obrigatório, contate o suporte!",
+    }),
 });
 
 export type CreateCategoryInput = z.infer<typeof createCategory>;

--- a/api/src/validators/company.ts
+++ b/api/src/validators/company.ts
@@ -1,10 +1,7 @@
 import { z } from "zod";
 
 export const createCompanySchema = z.object({
-    name: z.string({
-        required_error: "Nome da empresa é obrigatório!",
-        invalid_type_error: "Nome da empresa é obrigatório!",
-    }),
+    name: z.string().min(1, { message: "Nome da empresa é obrigatório!" }),
     isActive: z.boolean(),
 });
 

--- a/api/src/validators/company.ts
+++ b/api/src/validators/company.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const createCompanySchema = z.object({
+    name: z.string({
+        required_error: "Nome da empresa é obrigatório!",
+        invalid_type_error: "Nome da empresa é obrigatório!",
+    }),
+    isActive: z.boolean(),
+});
+
+export type CreateCompanyInput = z.infer<typeof createCompanySchema>;

--- a/api/src/validators/resources.ts
+++ b/api/src/validators/resources.ts
@@ -1,9 +1,22 @@
 import { z } from "zod";
 
 export const createResource = z.object({
-  name: z.string(),
-  description: z.string(),
-  categoryId: z.number(),
+    name: z.string({
+        required_error: "Nome do recurso é obrigatório!",
+        invalid_type_error: "Nome do recurso é obrigatório!",
+    }),
+    description: z.string({
+        required_error: "A descrição é obrigatório!",
+        invalid_type_error: "A descrição é obrigatório!",
+    }),
+    categoryId: z.number({
+        required_error: "A categoria é obrigatório!",
+        invalid_type_error: "A categoria é obrigatório!",
+    }),
+    companyId: z.number({
+        required_error: "Empresa é obrigatório, contate o suporte!",
+        invalid_type_error: "Empresa é obrigatório, contate o suporte!",
+    }),
 });
 
 export type CreateResourceInput = z.infer<typeof createResource>;


### PR DESCRIPTION
# Criando rota de new company

## Qual problema esse pull request resolve?
Para cadastrar uma empresa via aplicativo, é necessário registrar os dados do form no DB, sendo assim, neste PR foi criado a rota  `company` para salvar os dados da requisição no DB.
Foi feito melhorias em alguns repositories e validators, então, qualquer arquivo que não envolva a  rota de criação de company será considerado como melhorias, ressaltando que essa parte não é o foco desta tarefa, apenas vi que tinha que ser melhorado e aproveitei esse PR para fazer.


## Como o seu código resolve esse problema?
Foi necessário criar e registrar a rota `company`, solicitando as informações da requisição, e obtendo como retorno os dados salvos no DB. Dentro dessa rota os dados do form são enviados pro repository que ficará encarregado de inserir as informações no DB. E também, essas informações passam pelo validator `company` no qual contém a validação e o tipo dos campos (name e isActive).


## Quais os passos para testar essa feature/bug?

1.  Utilizar a request `create-company.http` (Rest Client);
2.  Fazer login com algum usuário válido e registrado em seu DB;
3.  Inserir os dados: nome da empresa e `isActive` como `true`;
4.  Para o teste ser considerado como sucesso a resposta tem que retornar a criação de uma empresa, com `companyId`, `name`, `isActive true`, `createdAt` e `updatedAt`. Qualquer resposta que não seja esses campos, citados acima, será considerado como erro, falha na criação de uma empresa.

Segue prints dos teste:

Teste de sucesso
![image](https://github.com/user-attachments/assets/1681ba75-d412-4284-b179-c08c7bb947bb)


Teste de falha
![image](https://github.com/user-attachments/assets/b472c959-6fff-4a2e-8ce9-f019b37eb1b9)

