### PR TITLE
Implementar o submit do form new company

### DIFF
--- a/web/src/app/new-company/components/new-company-form.tsx
+++ b/web/src/app/new-company/components/new-company-form.tsx
@@ -23,7 +23,7 @@ const FormSchema = z.object({
     name: z.string().min(1, {
         message: "O nome da empresa não pode estar vazio",
     }),
-    isActive: z.boolean().default(true),
+    isActive: z.boolean(),
 });
 
 export type NewCompanyFormSchema = z.infer<typeof FormSchema>;
@@ -53,7 +53,7 @@ export default function NewCompanyForm({ createCompany }: NewCompanyFormProps) {
 
             toast({
                 title: "Ótimo!",
-                description: "A empresa foi cadastrado com sucesso!",
+                description: "A empresa foi cadastrada com sucesso!",
                 action: (
                     <ToastAction
                         onClick={() => router.push("/")}
@@ -111,7 +111,10 @@ export default function NewCompanyForm({ createCompany }: NewCompanyFormProps) {
                                     <FormLabel>Está ativo?</FormLabel>
 
                                     <FormControl>
-                                        <Switch />
+                                        <Switch
+                                            checked={field.value}
+                                            onCheckedChange={field.onChange}
+                                        />
                                     </FormControl>
                                 </div>
                             </FormItem>

--- a/web/src/app/new-company/components/new-company-form.tsx
+++ b/web/src/app/new-company/components/new-company-form.tsx
@@ -11,8 +11,11 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
+import { ToastAction } from "@/components/ui/toast";
+import { useToast } from "@/components/ui/use-toast";
 import { zodResolver } from "@hookform/resolvers/zod";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
@@ -20,23 +23,63 @@ const FormSchema = z.object({
     name: z.string().min(1, {
         message: "O nome da empresa não pode estar vazio",
     }),
-    isActive: z.boolean().default(false),
+    isActive: z.boolean().default(true),
 });
 
 export type NewCompanyFormSchema = z.infer<typeof FormSchema>;
 
-export default function NewCompanyForm() {
+type NewCompanyFormProps = {
+    createCompany: (data: NewCompanyFormSchema) => void;
+};
+
+export default function NewCompanyForm({ createCompany }: NewCompanyFormProps) {
     const form = useForm<NewCompanyFormSchema>({
         resolver: zodResolver(FormSchema),
         defaultValues: {
             name: "",
-            isActive: false,
+            isActive: true,
         },
     });
 
+    const { toast } = useToast();
+
+    const router = useRouter();
+
+    async function onSubmit(data: NewCompanyFormSchema) {
+        try {
+            await createCompany(data);
+
+            form.reset();
+
+            toast({
+                title: "Ótimo!",
+                description: "A empresa foi cadastrado com sucesso!",
+                action: (
+                    <ToastAction
+                        onClick={() => router.push("/")}
+                        altText="Ir para a home"
+                    >
+                        Ir para a home
+                    </ToastAction>
+                ),
+            });
+        } catch (e) {
+            if (e instanceof Error) {
+                toast({
+                    variant: "destructive",
+                    title: "Algo não deu certo!",
+                    description: e.message,
+                });
+            }
+        }
+    }
+
     return (
         <Form {...form}>
-            <form className="flex flex-col gap-6">
+            <form
+                onSubmit={form.handleSubmit(onSubmit)}
+                className="flex flex-col gap-6"
+            >
                 <div className="flex flex-col gap-4">
                     <FormField
                         control={form.control}

--- a/web/src/app/new-company/page.tsx
+++ b/web/src/app/new-company/page.tsx
@@ -1,8 +1,34 @@
+import { revalidatePath } from "next/cache";
 import CompanyLogo from "../components/company-logo";
 import FormTitle from "../components/form-title";
-import NewCompanyForm from "./components/new-company-form";
+import NewCompanyForm, {
+    NewCompanyFormSchema,
+} from "./components/new-company-form";
 
 export default async function NewCompany() {
+    async function createCompany(data: NewCompanyFormSchema) {
+        "use server";
+
+        const body = {
+            ...data,
+        };
+
+        const response = await fetch("http://api:8080/company", {
+            method: "post",
+            headers: {
+                "content-type": "applicartion/json",
+            },
+            body: JSON.stringify(body),
+        });
+
+        if (response.status !== 201) {
+            const error = await response.json();
+            throw new Error(error.message);
+        }
+
+        revalidatePath("/");
+    }
+
     return (
         <section>
             <div className="h-40 px-6 py-12">
@@ -12,7 +38,7 @@ export default async function NewCompany() {
             <div className="p-6 flex flex-col gap-8">
                 <FormTitle>Criar uma empresa</FormTitle>
 
-                <NewCompanyForm />
+                <NewCompanyForm createCompany={createCompany} />
             </div>
         </section>
     );

--- a/web/src/app/new-company/page.tsx
+++ b/web/src/app/new-company/page.tsx
@@ -16,7 +16,7 @@ export default async function NewCompany() {
         const response = await fetch("http://api:8080/company", {
             method: "post",
             headers: {
-                "content-type": "applicartion/json",
+                "content-type": "application/json",
             },
             body: JSON.stringify(body),
         });


### PR DESCRIPTION
Implementando o submit do form new company

## Qual problema esse pull request resolve?
Este PR fica responsável por enviar as informações, preenchidas no form da tela new-company, para o beckend, ou seja, o botão "SALVAR" está funcionando, e armazena os dados, necessários para o cadastro de uma empresa, no DB.
Quero deixar uma observação: o switch `Está ativo?` por padrão virá como `true (ligado)`, porém é permitido cadastrar uma empresa com o switch `false (desligado)`. Porque é permitido cadastrar empresas como `true` ou `false`?, pois o campo `Está ativo?` se refere à indicação se a empresa está ativa ou não no nosso sistema, por exemplo, eu posso cadastrar uma empresa e deixa-lá ativa, e anos depois desativa-lá permitindo que esta empresa continue no nosso cadastro e na listagem de empresas, ou seja, a empresa está no nosso DB mas não está ativa. 

## Como o seu código resolve esse problema?
A função `createCompany` tem as informações do form e a rota que foi definida lá no beckend (`/company`).
A função `onSubmit` contém os toasts responsáveis pelas mensagens de alerta pro usuário e também chama a função `createCompany`.
A função `onSubmit` é chamado dentro da tag `form` através de um parâmetro.
Resumindo, quando o usuário clica no botão "SALVAR", as informações contidas no corpo da requisição são enviadas para a rota `/company` lá do backend, e também lança um alerta avisando se o cadastro foi um sucesso ou se deu erro.  


## Quais os passos para testar essa feature/bug?

1. Acesse o sitema via link: `http://localhost:3001/new-company`;
2. Preencha o campo nome, e faça um cadastro com o switch ligado e outro cadastro com switch desligado;
3. Observe se a mensagem do toast foi de sucesso, ou de erro;
4. Se a mensagem do toast foi de sucesso, verifique no prisma studio o cadastro da empresa que vc acabou de realizar.

Prints dos testes:

Cadastrando uma empresa com switch ligado
![image](https://github.com/user-attachments/assets/102e30f1-18d1-45b0-a3ac-8008b52c3a0a)

![image](https://github.com/user-attachments/assets/bfd20a47-e474-40ad-8823-73f2bf554dbb)


Cadastrando uma empresa com switch desligado
![image](https://github.com/user-attachments/assets/7d7c5a73-f2c6-4e50-8ae1-0696c91e7e8e)

![image](https://github.com/user-attachments/assets/6efc3175-8828-46f7-9fbc-936b9e152691)


Cadastro com erro
![image](https://github.com/user-attachments/assets/f6468660-adf1-4a31-a473-698c50961d89)


Cadastro de empresas diferente com mesmo nome
![image](https://github.com/user-attachments/assets/95478967-fecd-407d-8689-2bf8f8b9ad8a)


