### PR TITLE
Adicionando campos que identificam as empresas que foram cadastradas com nomes iguais

### DIFF
--- a/api/prisma/migrations/20240816193055_add_city_nickname_representative_name_to_company/migration.sql
+++ b/api/prisma/migrations/20240816193055_add_city_nickname_representative_name_to_company/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "Company" ADD COLUMN     "city" TEXT,
+ADD COLUMN     "nickname" TEXT,
+ADD COLUMN     "representativeName" TEXT;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -56,12 +56,15 @@ enum Level {
 }
 
 model Company {
-  id        Int        @id @default(autoincrement())
-  name      String
-  isActive  Boolean
-  createdAt DateTime   @default(now())
-  updatedAt DateTime   @default(now())
-  profile   Profile[]
-  resource  Resource[]
-  category  Category[]
+  id                 Int        @id @default(autoincrement())
+  name               String
+  isActive           Boolean
+  city               String?
+  nickname           String?
+  representativeName String?
+  createdAt          DateTime   @default(now())
+  updatedAt          DateTime   @default(now())
+  profile            Profile[]
+  resource           Resource[]
+  category           Category[]
 }

--- a/api/src/http/routes/create-company.ts
+++ b/api/src/http/routes/create-company.ts
@@ -4,11 +4,15 @@ import { createCompanySchema } from "./../../validators/company";
 
 export async function createCompany(server: FastifyInstance) {
     server.post("/company", async (request, reply) => {
-        const { name, isActive } = createCompanySchema.parse(request.body);
+        const { name, isActive, city, nickname, representativeName } =
+            createCompanySchema.parse(request.body);
 
         const company = await companyRepository.create({
             name,
             isActive,
+            city,
+            nickname,
+            representativeName,
         });
 
         return reply.status(201).send(company);

--- a/api/src/repositories/company.ts
+++ b/api/src/repositories/company.ts
@@ -2,11 +2,20 @@ import { prisma } from "../lib/prisma";
 import { CreateCompanyInput } from "../validators/company";
 
 class CompanyRepository {
-    async create({ name, isActive }: CreateCompanyInput) {
+    async create({
+        name,
+        isActive,
+        city,
+        nickname,
+        representativeName,
+    }: CreateCompanyInput) {
         const company = await prisma.company.create({
             data: {
                 name,
                 isActive,
+                city,
+                nickname,
+                representativeName,
             },
         });
 

--- a/api/src/validators/company.ts
+++ b/api/src/validators/company.ts
@@ -3,6 +3,11 @@ import { z } from "zod";
 export const createCompanySchema = z.object({
     name: z.string().min(1, { message: "Nome da empresa é obrigatório!" }),
     isActive: z.boolean(),
+    city: z.string().min(1, { message: "Nome da cidade é obrigatório!" }),
+    nickname: z.string().min(1, { message: "Apelido é obrigatório!" }),
+    representativeName: z
+        .string()
+        .min(1, { message: "Nome do representante é obrigatório!" }),
 });
 
 export type CreateCompanyInput = z.infer<typeof createCompanySchema>;

--- a/api/src/validators/company.ts
+++ b/api/src/validators/company.ts
@@ -3,11 +3,9 @@ import { z } from "zod";
 export const createCompanySchema = z.object({
     name: z.string().min(1, { message: "Nome da empresa é obrigatório!" }),
     isActive: z.boolean(),
-    city: z.string().min(1, { message: "Nome da cidade é obrigatório!" }),
-    nickname: z.string().min(1, { message: "Apelido é obrigatório!" }),
-    representativeName: z
-        .string()
-        .min(1, { message: "Nome do representante é obrigatório!" }),
+    city: z.string(),
+    nickname: z.string(),
+    representativeName: z.string(),
 });
 
 export type CreateCompanyInput = z.infer<typeof createCompanySchema>;

--- a/api/src/validators/profile.ts
+++ b/api/src/validators/profile.ts
@@ -5,10 +5,7 @@ export const createProfileSchema = z.object({
         required_error: "Nome é obrigatório!",
         invalid_type_error: "Nome é obrigatório!",
     }),
-    occupation: z.string({
-        required_error: "Ocupação é obrigatório!",
-        invalid_type_error: "Ocupação é obrigatório!",
-    }),
+    occupation: z.string(),
     email: z.string().email({ message: "E-mail inválido!" }),
     level: z.union([z.literal("USER"), z.literal("ADMIN"), z.literal("SUDO")]),
     companyId: z.number({

--- a/web/src/app/new-company/components/new-company-form.tsx
+++ b/web/src/app/new-company/components/new-company-form.tsx
@@ -24,6 +24,11 @@ const FormSchema = z.object({
         message: "O nome da empresa não pode estar vazio",
     }),
     isActive: z.boolean(),
+    city: z.string().min(1, { message: "Nome da cidade é obrigatório!" }),
+    nickname: z.string().min(1, { message: "Apelido é obrigatório!" }),
+    representativeName: z
+        .string()
+        .min(1, { message: "Nome do representante é obrigatório!" }),
 });
 
 export type NewCompanyFormSchema = z.infer<typeof FormSchema>;
@@ -38,6 +43,9 @@ export default function NewCompanyForm({ createCompany }: NewCompanyFormProps) {
         defaultValues: {
             name: "",
             isActive: true,
+            city: "",
+            nickname: "",
+            representativeName: "",
         },
     });
 
@@ -116,6 +124,69 @@ export default function NewCompanyForm({ createCompany }: NewCompanyFormProps) {
                                             onCheckedChange={field.onChange}
                                         />
                                     </FormControl>
+                                </div>
+                            </FormItem>
+                        )}
+                    />
+
+                    <FormField
+                        control={form.control}
+                        name="city"
+                        render={({ field }) => (
+                            <FormItem>
+                                <div className="flex flex-col gap-2">
+                                    <FormLabel>Cidade</FormLabel>
+                                    <FormControl>
+                                        <Input
+                                            id="city"
+                                            type="text"
+                                            placeholder="Ituiutaba, Uberlândia..."
+                                            {...field}
+                                        />
+                                    </FormControl>
+                                    <FormMessage />
+                                </div>
+                            </FormItem>
+                        )}
+                    />
+
+                    <FormField
+                        control={form.control}
+                        name="nickname"
+                        render={({ field }) => (
+                            <FormItem>
+                                <div className="flex flex-col gap-2">
+                                    <FormLabel>Apelido</FormLabel>
+                                    <FormControl>
+                                        <Input
+                                            id="nickname"
+                                            type="text"
+                                            placeholder="SPA das unhas, CI&E..."
+                                            {...field}
+                                        />
+                                    </FormControl>
+                                    <FormMessage />
+                                </div>
+                            </FormItem>
+                        )}
+                    />
+
+                    <FormField
+                        control={form.control}
+                        name="representativeName"
+                        render={({ field }) => (
+                            <FormItem>
+                                <div className="flex flex-col gap-2">
+                                    <FormLabel>Nome do representante</FormLabel>
+                                    <FormControl>
+                                        <Input
+                                            id="representativeName"
+                                            type="text"
+                                            placeholder="Josefina, Alceu..."
+                                            {...field}
+                                        />
+                                    </FormControl>
+                                    <FormMessage />
                                 </div>
                             </FormItem>
                         )}

--- a/web/src/app/new-company/components/new-company-form.tsx
+++ b/web/src/app/new-company/components/new-company-form.tsx
@@ -24,11 +24,9 @@ const FormSchema = z.object({
         message: "O nome da empresa não pode estar vazio",
     }),
     isActive: z.boolean(),
-    city: z.string().min(1, { message: "Nome da cidade é obrigatório!" }),
-    nickname: z.string().min(1, { message: "Apelido é obrigatório!" }),
-    representativeName: z
-        .string()
-        .min(1, { message: "Nome do representante é obrigatório!" }),
+    city: z.string(),
+    nickname: z.string(),
+    representativeName: z.string(),
 });
 
 export type NewCompanyFormSchema = z.infer<typeof FormSchema>;

--- a/web/src/app/new-profile/components/new-profile-form.tsx
+++ b/web/src/app/new-profile/components/new-profile-form.tsx
@@ -30,9 +30,7 @@ const formSchema = z.object({
     name: z.string().min(1, {
         message: "O nome do usuário não pode estar em branco",
     }),
-    occupation: z.string().min(1, {
-        message: "O cargo de ocupação não pode estar em branco",
-    }),
+    occupation: z.string(),
     email: z.string().email({
         message: "Digite um e-mail válido",
     }),


### PR DESCRIPTION
# Adicionar campos que identificam as empresas que foram cadastradas com nomes iguais

## Qual problema esse pull request resolve?
Nossa plataforma permite cadastrar empresas com nomes iguais, e a falta de distinção pode acabar confundindo o usuário de usar a empresa correta pro seu cadastro. Sendo assim, este PR adiciona os campos `city`, `nickname` e `representativeName` no momento de criar uma empresa, com o objetivo de diferenciar as empresas que foram cadastradas com o mesmo nome.


## Como o seu código resolve esse problema?
Foi adicionado os inputs, `city`, `nickname` e `representativeName`, na tela `new-company`. Esses novos dados enviados pela requisição, passam por uma validação e as informações são armazenados no DB, retornando como resposta um cadastro realizado com sucesso.


## Quais os passos para testar essa feature/bug?

1. Acessar a página: `http://localhost:3001/new-company`;
2. Realizar múltiplos cadastros de empresas, preenchendo os campos da tela. Fazer cadastros de empresas com nomes iguais, e o restante dos dados diferentes;
3. Checar no prisma studio (`http://localhost:5555/`) se os dados estão registrados no DB.

OBS.: Os campos `city`, `nickname` e `representativeName` não são obrigatórios, sendo assim, não será necessário excluir os dados existentes do DB, ou seja, vocês não precisarão excluir os cadastros que vocês já fizeram, basta apenas cadastrar uma nova empresa normalmente.

![image](https://github.com/user-attachments/assets/5a1bc7c1-868b-4d0c-8170-c3ac9d95930d)

![image](https://github.com/user-attachments/assets/9b6d8394-9c62-4c4c-9bb3-39e4b969a154)

