### PR TITLE
Alterado todos variáveis de 'title' para 'name'

### DIFF
--- a/api/prisma/migrations/20240827220347_add_name_category/migration.sql
+++ b/api/prisma/migrations/20240827220347_add_name_category/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `title` on the `Category` table. All the data in the column will be lost.
+  - Added the required column `name` to the `Category` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Category" DROP COLUMN "title",
+ADD COLUMN     "name" TEXT NOT NULL;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -15,7 +15,7 @@ datasource db {
 
 model Category {
   id        Int        @id @default(autoincrement())
-  title     String
+  name      String
   createdAt DateTime   @default(now())
   updatedAt DateTime   @default(now())
   resources Resource[]

--- a/api/requests/categories/create-category.http
+++ b/api/requests/categories/create-category.http
@@ -16,5 +16,6 @@ Content-Type: application/json
 Authorization: {{authToken}}
 
 {
-    "title": "Médicos"
+    "name": "Médicos",
+    "companyId": 1
 }

--- a/api/src/http/routes/create-categories.ts
+++ b/api/src/http/routes/create-categories.ts
@@ -5,10 +5,10 @@ import { createCategory } from "../../validators/categories";
 
 export async function createCategories(server: FastifyInstance) {
     server.post("/categories", async (request, reply) => {
-        const { title, companyId } = createCategory.parse(request.body);
+        const { name, companyId } = createCategory.parse(request.body);
 
         const category = await categoriesRepository.create({
-            title,
+            name,
             companyId,
         });
 

--- a/api/src/repositories/categories.ts
+++ b/api/src/repositories/categories.ts
@@ -2,10 +2,10 @@ import { prisma } from "../lib/prisma";
 import { CreateCategoryInput } from "../validators/categories";
 
 class CategoriesRepository {
-    async create({ title, companyId }: CreateCategoryInput) {
+    async create({ name, companyId }: CreateCategoryInput) {
         const category = await prisma.category.create({
             data: {
-                title,
+                name,
                 companyId,
             },
         });

--- a/api/src/validators/categories.ts
+++ b/api/src/validators/categories.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 export const createCategory = z.object({
-    title: z.string({
+    name: z.string({
         required_error: "Nome da categoria é obrigatório!",
         invalid_type_error: "Nome da categoria é obrigatório!",
     }),

--- a/web/src/app/new-category/page.tsx
+++ b/web/src/app/new-category/page.tsx
@@ -9,7 +9,7 @@ export default async function NewCategory() {
         "use server";
 
         const body = {
-            title: data.name,
+            name: data.name,
         };
 
         const response = await fetch("http://api:8080/categories", {

--- a/web/src/app/new-resource/components/new-resource-form.tsx
+++ b/web/src/app/new-resource/components/new-resource-form.tsx
@@ -157,7 +157,7 @@ export default function NewResourceForm({
                                                                 category.id,
                                                             )}
                                                         >
-                                                            {category.title}
+                                                            {category.name}
                                                         </SelectItem>
                                                     );
                                                 })}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -21,7 +21,7 @@ function transformResources(resources: ResourceResponse) {
         id,
         name,
         description,
-        category: category.title,
+        category: category.name,
     }));
 }
 

--- a/web/src/types/categories.ts
+++ b/web/src/types/categories.ts
@@ -1,6 +1,6 @@
 export type Category = {
     id: number;
-    title: string;
+    name: string;
 };
 
 export type CategoriesResponse = Array<

--- a/web/src/types/resources.ts
+++ b/web/src/types/resources.ts
@@ -13,7 +13,7 @@ export type ResourceResponse = Array<{
     categoryId: number;
     category: {
         id: number;
-        title: string;
+        name: string;
         createdAt: string;
         updatedAt: string;
     };


### PR DESCRIPTION
#MUDANÇA DA VARIÁVEL 'TITLE' PARA 'NAME'

## Qual problema esse pull request resolve?
Havia vários nomes de variáveis referente a tabela Categoria, onde alguns arquivos utilizam **'title'** e outro **'name'**. Para padronizar, este pull request modifica todas variáveis de **'title'** para **'name'** em todos arquivos relacionado à Categoria.


## Como o seu código resolve esse problema?
Para mudar o **'title'** para **'name'**, primeiramente atualizei o schema do Prisma e o banco de dados na tabela _'Category'_. Em seguida, modifiquei os arquivos relacionados à tabela. Por exemplo, no API, o arquivo create-categories.ts foi atualizado, assim como os demais arquivos relacionados.


## Quais os passos para testar essa feature/bug?
- No terminal, digite: **`make run`**.
- Para atualizar o schema prisma no local. No terminal, digite: **`cd api`** > **`npm i`** > **`npx prisma generate`** > **`make api`** > **`npx prisma generate`** >  **`npx prisma migrate dev`**.
- Com prisma studio vazio, dentro dele criar um nome de companhia e no rest client criar uma conta de usuário (`admin-create-profile.http`). 

Print de teste:
Criando uma categoria
![Captura de tela 2024-08-27 192511](https://github.com/user-attachments/assets/81e2a500-ab5f-41d3-bdb0-f7a06584feb8)

