### PR TITLE
Scrum 162 atualizar rotas de resource e category para usar token

### DIFF
--- a/api/requests/resources/create-resource.http
+++ b/api/requests/resources/create-resource.http
@@ -18,5 +18,6 @@ Authorization: {{authToken}}
 {
     "name": "Dr. Hudson Dodói",
     "description": "Ortopedista",
-    "categoryId": 1
+    "categoryId": 1,
+    "companyId": 1
 }

--- a/api/src/http/routes/create-categories.ts
+++ b/api/src/http/routes/create-categories.ts
@@ -17,11 +17,11 @@ export async function createCategories(server: FastifyInstance) {
 
         const { name, companyId } = createCategory.parse(request.body);
 
-        const profileSameCompany = verify(token, secretKey) as {
+        const profile = verify(token, secretKey) as {
             companyId: number;
         };
 
-        if (profileSameCompany.companyId !== companyId) {
+        if (profile.companyId !== companyId) {
             return reply.status(401).send({
                 message: "Você não tem permissão para executar esta operação!",
             });

--- a/api/src/http/routes/create-categories.ts
+++ b/api/src/http/routes/create-categories.ts
@@ -2,10 +2,30 @@ import { FastifyInstance } from "fastify";
 
 import categoriesRepository from "../../repositories/categories";
 import { createCategory } from "../../validators/categories";
+import { getToken } from "./utils/get-token";
+import { getJwtSecret } from "./utils/get-jwt-secret";
+import { verify } from "jsonwebtoken";
 
 export async function createCategories(server: FastifyInstance) {
     server.post("/categories", async (request, reply) => {
+        const token = getToken(request.headers);
+        const secretKey = getJwtSecret();
+
+        if (!token) {
+            return reply.status(400).send({ message: "Token inválido!" });
+        }
+
         const { name, companyId } = createCategory.parse(request.body);
+
+        const profileSameCompany = verify(token, secretKey) as {
+            companyId: number;
+        };
+
+        if (profileSameCompany.companyId !== companyId) {
+            return reply.status(401).send({
+                message: "Você não tem permissão para executar esta operação!",
+            });
+        }
 
         const category = await categoriesRepository.create({
             name,

--- a/api/src/http/routes/create-resources.ts
+++ b/api/src/http/routes/create-resources.ts
@@ -18,11 +18,11 @@ export async function createResources(server: FastifyInstance) {
         const { name, description, categoryId, companyId } =
             createResource.parse(request.body);
 
-        const profileSameCompany = verify(token, secretKey) as {
+        const profile = verify(token, secretKey) as {
             companyId: number;
         };
 
-        if (profileSameCompany.companyId !== companyId) {
+        if (profile.companyId !== companyId) {
             return reply.status(401).send({
                 message: "Você não tem permissão para executar esta operação!",
             });

--- a/api/src/http/routes/create-resources.ts
+++ b/api/src/http/routes/create-resources.ts
@@ -2,17 +2,37 @@ import { FastifyInstance } from "fastify";
 
 import resourcesRepository from "../../repositories/resources";
 import { createResource } from "../../validators/resources";
+import { getToken } from "./utils/get-token";
+import { verify } from "jsonwebtoken";
+import { getJwtSecret } from "./utils/get-jwt-secret";
 
 export async function createResources(server: FastifyInstance) {
     server.post("/resources", async (request, reply) => {
-        const { name, description, categoryId } = createResource.parse(
-            request.body,
-        );
+        const token = getToken(request.headers);
+        const secretKey = getJwtSecret();
+
+        if (!token) {
+            return reply.status(400).send({ message: "Token inválido!" });
+        }
+
+        const { name, description, categoryId, companyId } =
+            createResource.parse(request.body);
+
+        const profileSameCompany = verify(token, secretKey) as {
+            companyId: number;
+        };
+
+        if (profileSameCompany.companyId !== companyId) {
+            return reply.status(401).send({
+                message: "Você não tem permissão para executar esta operação!",
+            });
+        }
 
         const resource = await resourcesRepository.create({
             name,
             description,
             categoryId,
+            companyId,
         });
 
         return reply.status(201).send(resource);

--- a/api/src/http/routes/get-categories.ts
+++ b/api/src/http/routes/get-categories.ts
@@ -1,9 +1,25 @@
+import { verify } from "jsonwebtoken";
 import { FastifyInstance } from "fastify";
 import categoriesRepository from "../../repositories/categories";
+import { getToken } from "./utils/get-token";
+import { getJwtSecret } from "./utils/get-jwt-secret";
 
 export async function getCategories(server: FastifyInstance) {
     server.get("/categories", async (request, reply) => {
-        const categories = await categoriesRepository.findAll();
+        const token = getToken(request.headers);
+        const secretKey = getJwtSecret();
+
+        if (!token) {
+            return reply.send({ message: "Token inválido" });
+        }
+
+        const profile = verify(token, secretKey) as {
+            companyId: number;
+        };
+
+        const categories = await categoriesRepository.findAll(
+            profile.companyId,
+        );
 
         return reply.send(categories);
     });

--- a/api/src/http/routes/get-resources.ts
+++ b/api/src/http/routes/get-resources.ts
@@ -1,10 +1,24 @@
 import { FastifyInstance } from "fastify";
 
 import resourcesRepository from "../../repositories/resources";
+import { getToken } from "./utils/get-token";
+import { getJwtSecret } from "./utils/get-jwt-secret";
+import { verify } from "jsonwebtoken";
 
 export async function getResources(server: FastifyInstance) {
     server.get("/resources", async (request, reply) => {
-        const resources = await resourcesRepository.findAll();
+        const token = getToken(request.headers);
+        const secretKey = getJwtSecret();
+
+        if (!token) {
+            return reply.send({ message: "Token inválido!" });
+        }
+
+        const profile = verify(token, secretKey) as {
+            companyId: number;
+        };
+
+        const resources = await resourcesRepository.findAll(profile.companyId);
 
         return reply.send(resources);
     });

--- a/api/src/repositories/categories.ts
+++ b/api/src/repositories/categories.ts
@@ -13,8 +13,12 @@ class CategoriesRepository {
         return category;
     }
 
-    async findAll() {
-        const categories = await prisma.category.findMany();
+    async findAll(companyId: number) {
+        const categories = await prisma.category.findMany({
+            where: {
+                companyId,
+            },
+        });
 
         return categories;
     }

--- a/api/src/repositories/resources.ts
+++ b/api/src/repositories/resources.ts
@@ -20,8 +20,11 @@ class ResourcesRepository {
         return resource;
     }
 
-    async findAll() {
+    async findAll(companyId: number) {
         const resources = await prisma.resource.findMany({
+            where: {
+                companyId,
+            },
             include: {
                 category: true,
             },


### PR DESCRIPTION
# ATUALIZANDO DAS ROTAS DE CATEGORIAS E RECURSOS

## Qual problema esse pull request resolve?
As rotas de categorias e recursos estavam incompletas, pois não incluíam a parte de autenticação e verificação no banco de dados. Para resolver esse problema, foi adicionado o token de autenticação e verificação em cada arquivo relacionado a categorias, recursos e mensagem de erro de operação não permitido para o usuário não cadastrado, por exemplo, tentar criar uma categoria de outra companhia que isso não é permitido. Além disso, o Id da companhia, agora é obrigatório, foi incluído para garantir o acesso e .


## Como o seu código resolve esse problema?
O ajuste nas rotas de categorias e recursos foi realizado acrescentando o token e a verificação nos arquivos `create-categories.ts`, `get-categories.ts`, `create-resources.ts` e `get-resources.ts`, a rota de create foi colocado uma mensagem de erro não permitindo o SUDO/ADMIN/USER criar em uma outra companhia que não pertence. Além disso, o ID da companhia (_companyId_) foi inserido nos arquivos de repositório `categories.ts` e `resources.ts`, tanto para criação quanto para busca dentro da companhia. Também foi adicionado o campo _companyId_ no arquivo `create-resources.http`, uma vez que o Id da companhia é obrigatório.


## Quais os passos para testar essa feature/bug?
- No terminal digite, `make run`
- Para realizar teste, use a pasta requests (RestClient): create-categories.http, create-resources.http, get-categories.http e get-resources.http. 

Prints de teste:
Este é create-categories (SUDO):
![Captura de tela 2024-09-03 160026](https://github.com/user-attachments/assets/759a3971-46f8-4246-b65f-0a228f017f5d)

Mensagem de erro ao tentar criar categoria em outra companhia:
![Captura de tela 2024-09-03 160105](https://github.com/user-attachments/assets/3567ccb4-1851-4598-9048-fc59c6f99946)


Este é get-categories (SUDO):
![Captura de tela 2024-09-06 151314](https://github.com/user-attachments/assets/41daa337-2a83-4a4a-8c99-bc0236fa90c0)


Este é create-resources (USER):
![image](https://github.com/user-attachments/assets/e5d17421-7ff9-4528-8eea-41c8132c4e73)


Idem mensagem de erro USER não pertence a companhia:
![image](https://github.com/user-attachments/assets/a77dda32-0a42-43a2-85d2-86f8c7116bdd)



Este é get-resources (USER):
![image](https://github.com/user-attachments/assets/912fe149-8a8b-4542-a398-ce6cd2b88979)


