### PR TITLE
Connecting front-end and back-end of reset-password screen

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -2,6 +2,7 @@ import Fastify from "fastify";
 import { changePassword } from "./src/http/routes/change-password";
 import { createCategories } from "./src/http/routes/create-categories";
 import { createCompany } from "./src/http/routes/create-company";
+import CreateNewPassword from "./src/http/routes/create-new-password";
 import { createProfile } from "./src/http/routes/create-profile";
 import { createResources } from "./src/http/routes/create-resources";
 import { getCategories } from "./src/http/routes/get-categories";
@@ -32,6 +33,7 @@ server.register(createCompany);
 server.register(updateProfile);
 server.register(updateProfileActivate);
 server.register(ProfilesList);
+server.register(CreateNewPassword);
 
 server.listen({ port: 8080, host: "0.0.0.0" }, (err, address) => {
     if (err) {

--- a/api/requests/reset-password/reset-password.http
+++ b/api/requests/reset-password/reset-password.http
@@ -1,6 +1,19 @@
+# @name reset_password
 POST {{host}}/reset-password
 content-Type: application/json
 
 {
     "email": "sudo@marquei.com"
+}
+
+###
+@token = {{reset_password.response.body.$.token}}
+
+PATCH {{host}}/create-new-password
+content-Type: application/json
+
+{
+    "password": "1234567890",
+    "repeatPassword": "1234567890",
+    "token": {{token}}
 }

--- a/api/requests/reset-password/reset-password.http
+++ b/api/requests/reset-password/reset-password.http
@@ -13,7 +13,7 @@ PATCH {{host}}/create-new-password
 content-Type: application/json
 
 {
-    "password": "1234567890",
+    "newpassword": "1234567890",
     "repeatPassword": "1234567890",
-    "token": {{token}}
+    "token": "{{token}}"
 }

--- a/api/src/http/routes/create-new-password.ts
+++ b/api/src/http/routes/create-new-password.ts
@@ -52,7 +52,7 @@ export default async function createNewPassword(server: FastifyInstance) {
             });
         }
 
-        const profile = await profileRepository.findById(decoded.id, true);
+        const profile = await profileRepository.findById(decoded.id);
 
         if (!profile) {
             return reply
@@ -69,8 +69,7 @@ export default async function createNewPassword(server: FastifyInstance) {
             });
         }
 
-        const hashedPassword = await bcrypt.hash(newPassword, 10);
-        await profileRepository.updatePassword(profile.id, hashedPassword);
+        await profileRepository.updatePassword(profile.id, newPassword);
 
         return reply
             .status(httpCodes.SUCCESS)

--- a/api/src/http/routes/create-new-password.ts
+++ b/api/src/http/routes/create-new-password.ts
@@ -1,0 +1,80 @@
+import bcrypt from "bcrypt";
+import { FastifyInstance } from "fastify";
+import jwt from "jsonwebtoken";
+import { ZodError } from "zod";
+import profileRepository from "../../repositories/profiles";
+import {
+    CreateNewPasswordInput,
+    createNewPasswordSchema,
+} from "../../validators/create-new-password";
+import { getJwtSecret } from "./utils/get-jwt-secret";
+import httpCodes from "./utils/http-codes";
+
+export default async function createNewPassword(server: FastifyInstance) {
+    server.patch("/create-new-password", async (request, reply) => {
+        const secretKey = getJwtSecret();
+
+        const { token, ...passwordData } = request.body as {
+            token: string;
+            newPassword: string;
+            repeatPassword: string;
+        };
+
+        if (!token) {
+            return reply
+                .status(httpCodes.UNAUTHORIZED)
+                .send({ message: "Token inválido!" });
+        }
+
+        let decoded;
+        try {
+            decoded = jwt.verify(token, secretKey) as {
+                id: number;
+                expiresAt: number;
+            };
+            if (Date.now() > decoded.expiresAt) {
+                return reply
+                    .status(httpCodes.UNAUTHORIZED)
+                    .send({ message: "Token expirado!" });
+            }
+        } catch (error) {
+            return reply
+                .status(httpCodes.UNAUTHORIZED)
+                .send({ message: "Token inválido!" });
+        }
+
+        let createNewPassword: CreateNewPasswordInput;
+        try {
+            createNewPassword = createNewPasswordSchema.parse(passwordData);
+        } catch (error) {
+            return reply.status(httpCodes.BAD_REQUEST).send({
+                message: (error as ZodError).issues[0].message,
+            });
+        }
+
+        const profile = await profileRepository.findById(decoded.id, true);
+
+        if (!profile) {
+            return reply
+                .status(httpCodes.NOT_FOUND)
+                .send({ message: "Usuário não encontrado!" });
+        }
+
+        const { newPassword, repeatPassword } = createNewPassword;
+
+        if (newPassword !== repeatPassword) {
+            return reply.status(httpCodes.BAD_REQUEST).send({
+                message:
+                    "A confirmação de senha não coincide com a nova senha.",
+            });
+        }
+
+        const hashedPassword = await bcrypt.hash(newPassword, 10);
+        await profileRepository.updatePassword(profile.id, hashedPassword);
+
+        return reply
+            .status(httpCodes.SUCCESS)
+            .send({ message: "Senha atualizada com sucesso!" });
+    });
+}
+

--- a/api/src/http/routes/reset-password.ts
+++ b/api/src/http/routes/reset-password.ts
@@ -2,11 +2,11 @@ import { FastifyInstance } from "fastify";
 import jwt from "jsonwebtoken";
 import z from "zod";
 import profileRepository from "../../repositories/profiles";
+import emailService from "../../services/email";
 import {
     ResetPassword,
     resetPasswordSchema,
 } from "../../validators/reset-password";
-import emailService from "../../services/email";
 import { getJwtSecret } from "./utils/get-jwt-secret";
 import httpCodes from "./utils/http-codes";
 
@@ -33,7 +33,9 @@ export async function resetPassword(server: FastifyInstance) {
         const profile = await profileRepository.findByEmail(email);
 
         if (!profile) {
-            return reply.status(httpCodes.NOT_FOUND).send({ message: "Email inválido." });
+            return reply
+                .status(httpCodes.NOT_FOUND)
+                .send({ message: "Email inválido." });
         }
 
         const token = jwt.sign(
@@ -48,3 +50,4 @@ export async function resetPassword(server: FastifyInstance) {
         return reply.status(httpCodes.SUCCESS).send({ token });
     });
 }
+

--- a/api/src/validators/create-new-password.ts
+++ b/api/src/validators/create-new-password.ts
@@ -1,0 +1,12 @@
+import z from "zod";
+
+export const createNewPasswordSchema = z.object({
+    newPassword: z.string().min(8, {
+        message: "A senha nova deve conter no mínimo 8 caracteres.",
+    }),
+    repeatPassword: z.string().min(8, {
+        message: "A confirmação de senha deve conter no mínimo 8 caracteres.",
+    }),
+});
+
+export type CreateNewPasswordInput = z.infer<typeof createNewPasswordSchema>;

--- a/api/src/validators/create-new-password.ts
+++ b/api/src/validators/create-new-password.ts
@@ -1,6 +1,7 @@
 import z from "zod";
 
 export const createNewPasswordSchema = z.object({
+    token: z.string().min(1, { message: "O token é obrigatório." }),
     newPassword: z.string().min(8, {
         message: "A senha nova deve conter no mínimo 8 caracteres.",
     }),
@@ -10,3 +11,4 @@ export const createNewPasswordSchema = z.object({
 });
 
 export type CreateNewPasswordInput = z.infer<typeof createNewPasswordSchema>;
+

--- a/api/src/validators/create-new-password.ts
+++ b/api/src/validators/create-new-password.ts
@@ -1,7 +1,10 @@
 import z from "zod";
 
 export const createNewPasswordSchema = z.object({
-    token: z.string().min(1, { message: "O token é obrigatório." }),
+    token: z.string({
+        required_error: "O token é obrigatório.",
+        invalid_type_error: "Formato do token inválido.",
+    }),
     newPassword: z.string().min(8, {
         message: "A senha nova deve conter no mínimo 8 caracteres.",
     }),

--- a/web/src/app/reset-password/[token]/components/create-new-password-form.tsx
+++ b/web/src/app/reset-password/[token]/components/create-new-password-form.tsx
@@ -56,14 +56,6 @@ export default function CreateNewPasswordForm({
             toast({
                 title: "Ótimo!",
                 description: "Senha criada com sucesso.",
-                action: (
-                    <ToastAction
-                        onClick={() => router.push("/login")}
-                        altText="Ir para o login"
-                    >
-                        Ir para o login
-                    </ToastAction>
-                ),
             });
         } catch (e) {
             if (e instanceof Error) {

--- a/web/src/app/reset-password/[token]/components/create-new-password-form.tsx
+++ b/web/src/app/reset-password/[token]/components/create-new-password-form.tsx
@@ -10,8 +10,11 @@ import {
     FormLabel,
     FormMessage,
 } from "@/components/ui/form";
+import { ToastAction } from "@/components/ui/toast";
+import { useToast } from "@/components/ui/use-toast";
 import { zodResolver } from "@hookform/resolvers/zod";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
@@ -26,7 +29,13 @@ const FormSchema = z.object({
 
 export type CreateNewPasswordFormSchema = z.infer<typeof FormSchema>;
 
-export default function CreateNewPasswordForm() {
+type CreateNewPasswordFormProps = {
+    createNewPassword: (data: CreateNewPasswordFormSchema) => Promise<void>;
+};
+
+export default function CreateNewPasswordForm({
+    createNewPassword,
+}: CreateNewPasswordFormProps) {
     const form = useForm<CreateNewPasswordFormSchema>({
         resolver: zodResolver(FormSchema),
         defaultValues: {
@@ -35,7 +44,37 @@ export default function CreateNewPasswordForm() {
         },
     });
 
-    function onSubmit(data: CreateNewPasswordFormSchema) {}
+    const { toast } = useToast();
+    const router = useRouter();
+
+    async function onSubmit(data: CreateNewPasswordFormSchema) {
+        try {
+            await createNewPassword(data);
+
+            form.reset();
+
+            toast({
+                title: "Ótimo!",
+                description: "Senha criada com sucesso.",
+                action: (
+                    <ToastAction
+                        onClick={() => router.push("/login")}
+                        altText="Ir para o login"
+                    >
+                        Ir para o login
+                    </ToastAction>
+                ),
+            });
+        } catch (e) {
+            if (e instanceof Error) {
+                toast({
+                    variant: "destructive",
+                    title: "Algo não deu certo!",
+                    description: e.message,
+                });
+            }
+        }
+    }
 
     return (
         <Form {...form}>

--- a/web/src/app/reset-password/[token]/page.tsx
+++ b/web/src/app/reset-password/[token]/page.tsx
@@ -39,7 +39,7 @@ export default async function CreateNewPassword({
             throw new Error(data.message);
         }
 
-        revalidatePath("/login");
+        redirect("/login");
     }
 
     return (

--- a/web/src/app/reset-password/[token]/page.tsx
+++ b/web/src/app/reset-password/[token]/page.tsx
@@ -1,6 +1,9 @@
-import { redirect } from "next/navigation";
+import { revalidatePath } from "next/cache";
 import CompanyLogo from "../../components/company-logo";
-import CreateNewPasswordForm from "./components/create-new-password-form";
+import CreateNewPasswordForm, {
+    CreateNewPasswordFormSchema,
+} from "./components/create-new-password-form";
+import { redirect } from "next/navigation";
 
 type CreateNewPasswordProps = {
     params: {
@@ -8,9 +11,35 @@ type CreateNewPasswordProps = {
     };
 };
 
-export default function CreateNewPassword({ params }: CreateNewPasswordProps) {
+export default async function CreateNewPassword({
+    params,
+}: CreateNewPasswordProps) {
     if (!params.token) {
-        redirect("/reset-password");
+        return redirect("/reset-password");
+    }
+
+    async function createNewPassword(data: CreateNewPasswordFormSchema) {
+        "use server";
+
+        const body = {
+            ...data,
+            token: params.token,
+        };
+
+        const response = await fetch("http://api:8080/change-password", {
+            method: "PATCH",
+            headers: {
+                "content-type": "application/json",
+            },
+            body: JSON.stringify(body),
+        });
+
+        if (response.status !== 200) {
+            const data = (await response.json()) as { message: string };
+            throw new Error(data.message);
+        }
+
+        revalidatePath("/login");
     }
 
     return (
@@ -25,7 +54,9 @@ export default function CreateNewPassword({ params }: CreateNewPasswordProps) {
                 </h1>
 
                 <div className="py-4">
-                    <CreateNewPasswordForm />
+                    <CreateNewPasswordForm
+                        createNewPassword={createNewPassword}
+                    />
                 </div>
             </div>
         </section>

--- a/web/src/app/reset-password/[token]/page.tsx
+++ b/web/src/app/reset-password/[token]/page.tsx
@@ -26,7 +26,7 @@ export default async function CreateNewPassword({
             token: params.token,
         };
 
-        const response = await fetch("http://api:8080/change-password", {
+        const response = await fetch("http://api:8080/create-new-password", {
             method: "PATCH",
             headers: {
                 "content-type": "application/json",
@@ -62,3 +62,4 @@ export default async function CreateNewPassword({
         </section>
     );
 }
+

--- a/web/src/app/reset-password/components/send-email-form.tsx
+++ b/web/src/app/reset-password/components/send-email-form.tsx
@@ -1,42 +1,84 @@
-"use client"
+"use client";
 
 import { Button } from "@/components/ui/button";
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormLabel,
+    FormMessage,
+} from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { zodResolver } from "@hookform/resolvers/zod";
 import Link from "next/link";
 import { useForm } from "react-hook-form";
-import { z } from "zod"
+import { z } from "zod";
+import { useToast } from "@/components/ui/use-toast";
 
 const FormSchema = z.object({
     email: z.string().email({
-        message: "Email inválido."
-    })
-})
+        message: "Email inválido.",
+    }),
+});
 
 export type SendEmailFormSchema = z.infer<typeof FormSchema>;
 
-export default function SendEmailForm() {
+type SendEmailFormProps = {
+    requestPasswordReset: (data: SendEmailFormSchema) => void;
+};
+
+export default function SendEmailForm({
+    requestPasswordReset,
+}: SendEmailFormProps) {
     const form = useForm<SendEmailFormSchema>({
         resolver: zodResolver(FormSchema),
         defaultValues: {
-            email: ""
-        }
-    })
+            email: "",
+        },
+    });
 
-    function onSubmit(data: SendEmailFormSchema) {}
+    const { toast } = useToast();
+
+    async function onSubmit(data: SendEmailFormSchema) {
+        try {
+            await requestPasswordReset(data);
+            form.reset();
+
+            toast({
+                title: "Solicitação enviada!",
+                description:
+                    "Verifique seu email para continuar com a recuperação de senha.",
+            });
+        } catch (e) {
+            toast({
+                variant: "destructive",
+                title: "Erro na solicitação!",
+                description:
+                    e instanceof Error
+                        ? e.message
+                        : "Ocorreu um erro ao tentar solicitar a recuperação de senha.",
+            });
+        }
+    }
 
     return (
         <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)}>
+            <form
+                onSubmit={form.handleSubmit(onSubmit)}
+                className="flex flex-col gap-6"
+            >
                 <FormField
                     control={form.control}
                     name="email"
                     render={({ field }) => (
-                        <FormItem className="pb-4">
-                            <FormLabel className="font-bold">E-mail</FormLabel>
+                        <FormItem className="flex flex-col gap-2">
+                            <FormLabel htmlFor="email" className="font-bold">
+                                E-mail
+                            </FormLabel>
                             <FormControl>
                                 <Input
+                                    id="email"
                                     type="email"
                                     placeholder="Digite seu email"
                                     {...field}
@@ -46,10 +88,10 @@ export default function SendEmailForm() {
                         </FormItem>
                     )}
                 />
-                <div className="space-y-2 flex flex-col">
+                <div className="flex flex-col gap-2">
                     <Button
                         type="submit"
-                        className="bg-indigo-950 rounded-full text-base"
+                        className="bg-indigo-950 rounded-full font-bold text-base"
                     >
                         SOLICITAR RECUPERAÇÃO
                     </Button>

--- a/web/src/app/reset-password/page.tsx
+++ b/web/src/app/reset-password/page.tsx
@@ -1,21 +1,41 @@
 import CompanyLogo from "../components/company-logo";
-import SendEmailForm from "./components/send-email-form";
+import SendEmailForm, {
+    SendEmailFormSchema,
+} from "./components/send-email-form";
 
 export default function ResetPassword() {
+    async function requestPasswordReset(data: SendEmailFormSchema) {
+        "use server";
+        const response = await fetch("http://api:8080/reset-password", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify(data),
+        });
+
+        if (response.status !== 200) {
+            const errorData = await response.json();
+            throw new Error(errorData.message);
+        }
+    }
+
     return (
         <section className="px-6 py-12 flex flex-col flex-wrap gap-9">
             <div>
                 <CompanyLogo />
             </div>
 
-            <div className="">
+            <div>
                 <h1 className="text-3xl font-bold text-indigo-950">
                     Recuperar senha
                 </h1>
                 <h2>Esqueceu sua senha? Deixa com a gente!</h2>
 
                 <div className="py-4">
-                    <SendEmailForm />
+                    <SendEmailForm
+                        requestPasswordReset={requestPasswordReset}
+                    />
                 </div>
             </div>
         </section>


### PR DESCRIPTION
# Fazendo o fluxo de reset de senha funcionar completamente

## Qual problema esse pull request resolve?
Esse PR conecta o front-end e back-end da tela reset password e permite que seja possível realizar o fluxo completo de reset de senha pelo front-end.


## Como o seu código resolve esse problema?

Quando o usuário pede para redefinir a senha, o back-end gera um token temporário e envia para o slack. Esse token prova que o pedido é válido e foi autorizado. O token gerado se torna um complemento da url http://localhost:3001/reset-password e através dessa url o usuário acessa a tela onde é possível criar a nova senha.

No momento da redefinição, o código verifica se a nova senha e a confirmação estão corretas e correspondem entre si. Em seguida, a nova senha é criptografada e salva no banco de dados.

Após isso o usuário e redirecionado automaticamente para a tela de login onde ele pode acessar a aplicação com sua nova senha.

## Quais os passos para testar essa feature/bug?

- Acessar `http://localhost:3001/reset-password`

- Digitar o e-mail e clicar no botão SOLICITAR RECUPERAÇÃO

![image](https://github.com/user-attachments/assets/3e717807-cd40-4d73-881e-4c9f19b79e20)

- Acessar o slack e clicar no link gerado

![image](https://github.com/user-attachments/assets/c33c7fd7-422a-426d-a96f-38abd1a5d243)

- Digitar a nova senha e por fim clicar em ALTERAR SENHA

![image](https://github.com/user-attachments/assets/f87ef40b-84f8-4808-8fc6-96b15ed6efd3)


