### PR TITLE
Erros corrigidos - Tela Novo Perfil

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -14,6 +14,7 @@ import { updateProfile } from "./src/http/routes/profile-deactivate";
 import { ProfilesList } from "./src/http/routes/profiles-list";
 import { resetPassword } from "./src/http/routes/reset-password";
 import { sudoLogin } from "./src/http/routes/sudo-login";
+import { getCompanies } from "./src/http/routes/get-companies";
 
 const server = Fastify();
 
@@ -32,6 +33,7 @@ server.register(createCompany);
 server.register(updateProfile);
 server.register(updateProfileActivate);
 server.register(ProfilesList);
+server.register(getCompanies);
 
 server.listen({ port: 8080, host: "0.0.0.0" }, (err, address) => {
     if (err) {

--- a/api/requests/company/get-companies.http
+++ b/api/requests/company/get-companies.http
@@ -1,0 +1,15 @@
+# @name login
+POST {{host}}/login
+Content-Type: application/json
+
+{
+    "email": "admin@marquei.com",
+    "password": "1234567890"
+}
+
+###
+
+@authToken = Bearer {{login.response.body.$.token}}
+
+GET {{host}}/companies
+Authorization: {{authToken}}

--- a/api/src/http/routes/get-companies.ts
+++ b/api/src/http/routes/get-companies.ts
@@ -1,0 +1,30 @@
+import { FastifyInstance } from "fastify";
+import { getToken } from "./utils/get-token";
+import { getJwtSecret } from "./utils/get-jwt-secret";
+import { verify } from "jsonwebtoken";
+import { Level } from "@prisma/client";
+import companyRepository from "../../repositories/company";
+
+export async function getCompanies(server: FastifyInstance) {
+    server.get("/companies", async (request, reply) => {
+        const token = getToken(request.headers);
+        const secretKey = getJwtSecret();
+
+        if (!token) {
+            return reply.status(400).send({ message: "Token inválido!" });
+        }
+
+        const profile = verify(token, secretKey) as {
+            level: Level;
+            companyId: number;
+        };
+        
+        const companies = await companyRepository.find(
+            profile.level,
+            profile.companyId,
+        );
+
+        return reply.send(companies);
+    })
+    
+}

--- a/api/src/repositories/company.ts
+++ b/api/src/repositories/company.ts
@@ -21,6 +21,19 @@ class CompanyRepository {
 
         return company;
     }
+
+    async find(level: string, companyId: number) {
+        if (level === "SUDO") {
+            return await prisma.company.findMany();
+        }
+
+        return await prisma.company.findMany({
+            where: {
+                id: companyId,
+            },
+        });
+    }
+
 }
 
 const companyRepository = new CompanyRepository();

--- a/web/src/app/new-profile/components/new-profile-form.tsx
+++ b/web/src/app/new-profile/components/new-profile-form.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/components/ui/select";
 import { ToastAction } from "@/components/ui/toast";
 import { useToast } from "@/components/ui/use-toast";
+import { Company } from "@/types/companies";
 import { zodResolver } from "@hookform/resolvers/zod";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -37,18 +38,24 @@ const formSchema = z.object({
     level: z.string().min(1, {
         message: "Selecione um dos níveis de perfil da lista.",
     }),
-});
+    companyId: z.string().min(1, {
+        message: "Selecione uma empresa."
+    }),
+})
+
 
 export type NewProfileFormSchema = z.infer<typeof formSchema>;
 
 type NewProfileFormProps = {
     levels: Array<string>;
-    createProfile: (data: NewProfileFormSchema) => void;
+    createProfile: (data: NewProfileFormSchema) => Promise<void>;
+    companies: Array<Company>;
 };
 
 export default function NewProfileForm({
     levels,
     createProfile,
+    companies
 }: NewProfileFormProps) {
     const form = useForm<NewProfileFormSchema>({
         resolver: zodResolver(formSchema),
@@ -57,6 +64,7 @@ export default function NewProfileForm({
             occupation: "",
             email: "",
             level: "",
+            companyId:"",
         },
     });
 
@@ -77,6 +85,7 @@ export default function NewProfileForm({
 
     async function onSubmit(data: NewProfileFormSchema) {
         try {
+
             await createProfile(data);
 
             form.reset();
@@ -228,10 +237,53 @@ export default function NewProfileForm({
                             );
                         }}
                     />
+
+                    <FormField
+                        control={form.control}
+                        name="companyId"
+                        render={({ field }) => {
+                            return (
+                                <FormItem>
+                                    <div className="flex flex-col gap-2">
+                                        <FormLabel htmlFor="companyId">
+                                            Empresa
+                                        </FormLabel>
+                                        <Select
+                                            value={field.value} 
+                                            defaultValue={field.value} 
+                                            onValueChange={field.onChange}
+                                        >
+                                            <FormControl>
+                                                <SelectTrigger>
+                                                    <SelectValue
+                                                        id="companyId"
+                                                        placeholder="Escolha uma empresa"
+                                                        {...field}
+                                                    />
+                                                </SelectTrigger>
+                                            </FormControl>
+                                            <SelectContent>
+                                                {companies.map((company) => {
+                                                    return (
+                                                        <SelectItem
+                                                            key={company.id}
+                                                            value={String(company.id)}
+                                                        >
+                                                            {company.name}
+                                                        </SelectItem>
+                                                    );
+                                                })}
+                                            </SelectContent>
+                                        </Select>
+                                    </div>
+                                </FormItem>
+                            );
+                        }}
+                    />
                 </div>
 
                 <div className="flex flex-col gap-2">
-                    <Button className="bg-indigo-950 font-bold">SALVAR</Button>
+                    <Button type="submit" className="bg-indigo-950 font-bold">SALVAR</Button>
 
                     <Button
                         asChild
@@ -245,3 +297,7 @@ export default function NewProfileForm({
         </Form>
     );
 }
+function register(arg0: string, arg1: { value: string; }): import("react").JSX.IntrinsicAttributes & import("react").ClassAttributes<HTMLInputElement> & import("react").InputHTMLAttributes<HTMLInputElement> {
+    throw new Error("Function not implemented.");
+}
+

--- a/web/src/types/companies.ts
+++ b/web/src/types/companies.ts
@@ -1,0 +1,10 @@
+export type Company = {
+    id: number;
+    name: string;
+}
+
+export type CompanyResponse = Company & {
+    createdAt: string;
+    updatedAt: string;
+};
+

--- a/web/src/types/profiles.ts
+++ b/web/src/types/profiles.ts
@@ -4,6 +4,7 @@ export type Profile = {
     occupation: string;
     email: string;
     level: string;
+    companyId: number;
 };
 
 export type ProfilesResponse = Profile & {


### PR DESCRIPTION
# TELA DE NOVO PERFIL FUNCIONANDO

## Qual problema esse pull request resolve?
A tela de **"Novo Perfil"** estava apresentando um erro 500 (Internal Server Error). Inicialmente, foi necessário identificar o problema para exibir corretamente a tela de **"Novo Perfil"**. Durante os testes, novos erros apareceram ao salvar, especialmente relacionados ao campo companyId, que é obrigatório. No frontend, foi adicionada uma caixa de seleção que mostra uma lista de empresas (Fica visível somente SUDO) ou uma empresa (Visível somente ADMIN). Usuários com nível USER verá uma tela 404 (Sem permissão para criar um novo perfil).

## Como o seu código resolve esse problema?
Para fazer a tela de **"Novo Perfil"** funcionar corretamente foram:
- No frontend, foi inserido um token na função getLevels para que a seleção de nível exiba as opções de perfil de acordo com o nível do usuário logado.
- Para corrigir o erro relacionado ao companyId, foi adicionada outro combobox tendo a lista de empresas, logo abaixo da seleção de nível de perfil, permitindo que usuários SUDO escolham entre várias empresas.
- Para mostra a lista de empresas no frontend, foi adicionada uma rota **getCompanies.http** na API para buscar a lista de empresas. No repositório, foi criado a função **find()** que usa o **findMany()** para retornar uma lista de empresas (ou uma empresa, no caso de usuários ADMIN).
- No frontend, o companyId é convertido de string para number antes de ser enviado ao banco de dados.
- O JWT é decodificado para capturar o nível do usuário e verificar se ele é do nível USER; neste caso, retorna uma resposta 404 (not found).

## Quais os passos para testar essa feature/bug?
- No terminal, digite `make run`.
- No navegador, acesse [localhost:3001/new-profile](url) para testar:
             -  Usuários SUDO logados verão uma lista de empresas para selecionar;
             -  Usuários ADMIN logados verão apenas a empresa a que pertencem;
             -  Usuários USER logados verão a tela 404, pois não têm permissão.

Prints de testes:

Usuário SUDO logado:
![Captura de tela 2024-11-05 114443](https://github.com/user-attachments/assets/fc80aa00-b206-4184-913c-26ac1ac33831)

SUDO criando um novo perfil em outra empresa e está salvo no prisma as informações:
![Captura de tela 2024-11-05 114627](https://github.com/user-attachments/assets/2e9284ff-d8ff-476c-ace5-7a7f74b9c4c1)

Usuário ADMIN logado:
![Captura de tela 2024-11-05 114712](https://github.com/user-attachments/assets/34953673-2e27-4024-8878-b239300a2b3a)

ADMIN criando um novo perfil da mesma empresa:
![Captura de tela 2024-11-05 114804](https://github.com/user-attachments/assets/b918401a-cf92-419a-98d4-58345dea0ef2)

Usuário USER logado:
![Captura de tela 2024-11-05 115031](https://github.com/user-attachments/assets/0cb064bd-b72e-4ed3-b745-44646e7c6572)



