### PR TITLE
Solved error on new category screen

### DIFF
--- a/web/src/app/new-category/component/new-category-form.tsx
+++ b/web/src/app/new-category/component/new-category-form.tsx
@@ -22,27 +22,21 @@ const FormSchema = z.object({
     name: z.string().min(1, {
         message: "O nome da categoria não pode estar vazio.",
     }),
-    companyId: z.string().min(1, {
-        message: "Empresa é obrigatório, contate o suporte!",
-    }),
 });
 
 export type NewCategoryFormSchema = z.infer<typeof FormSchema>;
 
 type NewCategoryFormProps = {
     createCategory: (data: NewCategoryFormSchema) => Promise<void>;
-    companyId: number;
 };
 
 export default function NewCategoryForm({
     createCategory,
-    companyId,
 }: NewCategoryFormProps) {
     const form = useForm<NewCategoryFormSchema>({
         resolver: zodResolver(FormSchema),
         defaultValues: {
             name: "",
-            companyId: String(companyId),
         },
     });
 
@@ -102,23 +96,6 @@ export default function NewCategoryForm({
                                 />
                             </FormControl>
 
-                            <FormMessage />
-                        </FormItem>
-                    )}
-                />
-
-                <FormField
-                    control={form.control}
-                    name="companyId"
-                    render={({ field }) => (
-                        <FormItem>
-                            <FormControl>
-                                <Input
-                                    id="companyId"
-                                    type="hidden"
-                                    {...field}
-                                />
-                            </FormControl>
                             <FormMessage />
                         </FormItem>
                     )}

--- a/web/src/app/new-category/component/new-category-form.tsx
+++ b/web/src/app/new-category/component/new-category-form.tsx
@@ -107,6 +107,23 @@ export default function NewCategoryForm({
                     )}
                 />
 
+                <FormField
+                    control={form.control}
+                    name="companyId"
+                    render={({ field }) => (
+                        <FormItem>
+                            <FormControl>
+                                <Input
+                                    id="companyId"
+                                    type="hidden"
+                                    {...field}
+                                />
+                            </FormControl>
+                            <FormMessage />
+                        </FormItem>
+                    )}
+                />
+
                 <div className="flex flex-col gap-2">
                     <Button type="submit" className="text-base font-bold">
                         SALVAR

--- a/web/src/app/new-category/component/new-category-form.tsx
+++ b/web/src/app/new-category/component/new-category-form.tsx
@@ -22,21 +22,27 @@ const FormSchema = z.object({
     name: z.string().min(1, {
         message: "O nome da categoria não pode estar vazio.",
     }),
+    companyId: z.string().min(1, {
+        message: "Empresa é obrigatório, contate o suporte!",
+    }),
 });
 
 export type NewCategoryFormSchema = z.infer<typeof FormSchema>;
 
 type NewCategoryFormProps = {
-    createCategory: (data: NewCategoryFormSchema) => void;
+    createCategory: (data: NewCategoryFormSchema) => Promise<void>;
+    companyId: number;
 };
 
 export default function NewCategoryForm({
     createCategory,
+    companyId,
 }: NewCategoryFormProps) {
     const form = useForm<NewCategoryFormSchema>({
         resolver: zodResolver(FormSchema),
         defaultValues: {
             name: "",
+            companyId: String(companyId),
         },
     });
 
@@ -100,6 +106,7 @@ export default function NewCategoryForm({
                         </FormItem>
                     )}
                 />
+
                 <div className="flex flex-col gap-2">
                     <Button type="submit" className="text-base font-bold">
                         SALVAR

--- a/web/src/app/new-category/page.tsx
+++ b/web/src/app/new-category/page.tsx
@@ -5,6 +5,7 @@ import NewCategoryForm, {
 } from "./component/new-category-form";
 import getSession from "../utis/get-session";
 import { redirect } from "next/navigation";
+import { jwtDecode } from "jwt-decode";
 
 export default async function NewCategory() {
     const session = getSession();
@@ -13,12 +14,21 @@ export default async function NewCategory() {
         return redirect("/login");
     }
 
+    const decoded = jwtDecode(session) as {
+        companyId: number;
+    };
+
+    const companyId = decoded.companyId;
+
     async function createCategory(data: NewCategoryFormSchema) {
         "use server";
 
         const body = {
-            name: data.name,
+            ...data,
+            companyId: Number(data.companyId),
         };
+
+        console.log("Checando:", body);
 
         const response = await fetch("http://api:8080/categories", {
             method: "post",
@@ -47,7 +57,10 @@ export default async function NewCategory() {
                     Nova Categoria
                 </h1>
 
-                <NewCategoryForm createCategory={createCategory} />
+                <NewCategoryForm
+                    createCategory={createCategory}
+                    companyId={companyId}
+                />
             </div>
         </section>
     );

--- a/web/src/app/new-category/page.tsx
+++ b/web/src/app/new-category/page.tsx
@@ -25,7 +25,7 @@ export default async function NewCategory() {
 
         const body = {
             ...data,
-            companyId: Number(data.companyId),
+            companyId,
         };
 
         const response = await fetch("http://api:8080/categories", {
@@ -55,10 +55,7 @@ export default async function NewCategory() {
                     Nova Categoria
                 </h1>
 
-                <NewCategoryForm
-                    createCategory={createCategory}
-                    companyId={companyId}
-                />
+                <NewCategoryForm createCategory={createCategory} />
             </div>
         </section>
     );

--- a/web/src/app/new-category/page.tsx
+++ b/web/src/app/new-category/page.tsx
@@ -28,8 +28,6 @@ export default async function NewCategory() {
             companyId: Number(data.companyId),
         };
 
-        console.log("Checando:", body);
-
         const response = await fetch("http://api:8080/categories", {
             method: "post",
             headers: {

--- a/web/src/types/categories.ts
+++ b/web/src/types/categories.ts
@@ -1,6 +1,7 @@
 export type Category = {
     id: number;
     name: string;
+    companyId: number;
 };
 
 export type CategoriesResponse = Array<


### PR DESCRIPTION
# PROBLEMA RESOLVIDO: ERRO NA TELA DE NOVA CATEGORIA

## Qual problema esse pull request resolve?
Ao fazer teste da tela apresentou erro de companyId que é obrigatório. Para resolver o problema, foram adicionados o companyId nos arquivos. Também foi incluída a lógica para decodificar o session e obter o companyId do usuário logado para fazer a criação de nova categoria.


## Como o seu código resolve esse problema?
Os passos para a resolução do problema foram:
- Foi identificado um erro relacionado ao companyId, então ele foi adicionado ao arquivo `new-category-form.tsx` no **FormSchema**, na **Props** e no **FormField**. Da mesma forma, foi incluído na pasta **types**.
- No campo FormField do **companyId**, foi definido a tag Input do type="hidden", para que o usuário não veja na tela, mas ainda será enviado nos dados.
- Antes de enviar para o banco de dados, o **companyId** passa por uma conversão de **string** para o **number**.
- Foi adicionado o jwt.decode para decodificar a sessão e obter o companyId do usuário logado, permitindo a criação da nova categoria.


## Quais os passos para testar essa feature/bug?
- No terminal, foi instalado o pacote lucide-react: 
	- Digite os comandos: `cd web && npm i && make web && npm i.`
	- Em seguida: `make run`
- Abra o navegador e acesse [localhost:3001/new-category](url) para testar a criação de uma nova categoria. 
	
Prints de cada nível de usuário:
SUDO/ADMIN/USER - Prisma studio

![Captura de tela 2024-11-14 115940](https://github.com/user-attachments/assets/ae7ac936-b8cd-48de-a73a-5f0ff14ce20a)

