### PR TITLE
Solved error on new resource screen

### DIFF
--- a/web/src/types/resources.ts
+++ b/web/src/types/resources.ts
@@ -2,6 +2,7 @@ export type Resource = {
     name: string;
     description: string;
     category: string;
+    companyId: number;
 };
 
 export type ResourceResponse = Array<{
@@ -11,9 +12,11 @@ export type ResourceResponse = Array<{
     createdAt: string;
     updatedAt: string;
     categoryId: number;
+    companyId: number;
     category: {
         id: number;
         name: string;
+        companyId: number;
         createdAt: string;
         updatedAt: string;
     };


### PR DESCRIPTION
# ERRO RESOLVIDO: TELA NOVO RECURSO

## Qual problema esse pull request resolve?
Este pull request resolve erros relacionados ao categories.map e a falta de companyId (“Empresa é obrigatório, contate o suporte”). A solução foi adicionar o token na função getCategories para que a tela fosse exibida corretamente. Portanto, foi feita uma decodificação na sessão para obter o companyId do usuário para criar um novo recurso.


## Como o seu código resolve esse problema?
- Adicionado o token na função **getCategories**. Com a mudança, a tela voltou a ser exibida corretamente;
- Decodifica a sessão para obter o companyId do usuário logado e permitindo que esse valor seja enviado ao banco de dados.


## Quais os passos para testar essa feature/bug?
- No terminal, execute o comando `“make run”`
- Abre o navegador e acesse [localhost:3001/new-resources](url) para testar a criação de um novo recurso.

Print de teste:
SUDO:
![Captura de tela 2024-11-21 172117](https://github.com/user-attachments/assets/e2827dfd-bafa-4c71-9ee5-9f40f7377a24)

ADMIN:
![Captura de tela 2024-11-22 141541](https://github.com/user-attachments/assets/095aae62-b1cc-4153-984c-a82ee8fb28e8)

USER:
![Captura de tela 2024-11-22 141713](https://github.com/user-attachments/assets/9846653e-6590-44ed-8c84-ee542f81d153)
