### PR TITLE
2 lines of description (style)

### DIFF
--- a/web/src/app/components/resources-card.tsx
+++ b/web/src/app/components/resources-card.tsx
@@ -17,7 +17,7 @@ export default function ResourcesCard({ resource }: ResourceCardProps) {
                             {resource.name}
                         </h2>
 
-                        <p className="text-slate-500 text-xs">
+                        <p className="text-slate-500 text-xs line-clamp-2">
                             {resource.description}
                         </p>
                     </div>


### PR DESCRIPTION
# CRIANDO UM ESTILO PARA DESCRIÇÃO DE RECURSO

## Qual problema esse pull request resolve?
Este pull request foi criado para melhorar o estilo de descrição mostrada abaixo do recurso. Antes, em cada descrição apresentava as frases sem fim, ultrapassando 4 linhas. Agora, foi definido de ter 2 linhas para a descrição. 


## Como o seu código resolve esse problema?
A solução foi utilizando Tailwind CSS. Adicionei a classe line-clamp-* ( * indica o número de linhas desejado) no componente resource-card, especificamente no estilo da descrição (Onde tem o campo description).


## Quais os passos para testar essa feature/bug?
- Abre o navegador e acesso [localhost:3001/](url) e verifique a mudança do estilo da descrição dos recursos mostra as 2 linhas.

Prints testes:
Antes:
![Captura de tela 2024-11-23 161115](https://github.com/user-attachments/assets/876b73f8-47e6-4648-846f-51a72d5d9ebb)

Depois:
![Captura de tela 2024-11-23 161226](https://github.com/user-attachments/assets/3df1c173-da1f-4b47-8269-9741960008bd)

