### PR TITLE
ADMIN/USER don't see screen "Create Company"

### DIFF
--- a/api/src/http/routes/create-company.ts
+++ b/api/src/http/routes/create-company.ts
@@ -2,20 +2,45 @@ import { FastifyInstance } from "fastify";
 import companyRepository from "../../repositories/company";
 import { createCompanySchema } from "./../../validators/company";
 import httpCodes from "./utils/http-codes";
+import { getToken } from "./utils/get-token";
+import { getJwtSecret } from "./utils/get-jwt-secret";
+import { verify } from "jsonwebtoken";
+import { Level } from "@prisma/client";
 
 export async function createCompany(server: FastifyInstance) {
     server.post("/company", async (request, reply) => {
+        const token = getToken(request.headers);
+        const secretKey = getJwtSecret();
+
+        if (!token) {
+            return reply
+                .status(httpCodes.BAD_REQUEST)
+                .send({ message: "Token inválido!" });
+        }
+
+        const profile = verify(token, secretKey) as {
+            level: Level;
+        };
+
         const { name, isActive, city, nickname, representativeName } =
             createCompanySchema.parse(request.body);
 
-        const company = await companyRepository.create({
-            name,
-            isActive,
-            city,
-            nickname,
-            representativeName,
-        });
+        const isSudo = profile.level === Level.SUDO;
 
-        return reply.status(httpCodes.CREATED).send(company);
+        if (isSudo) {
+            const company = await companyRepository.create({
+                name,
+                isActive,
+                city,
+                nickname,
+                representativeName,
+            });
+
+            return reply.status(httpCodes.CREATED).send(company);
+        }
+
+        return reply.status(httpCodes.UNAUTHORIZED).send({
+            message: "Você não tem permissão para executar esta operação!",
+        });
     });
 }

--- a/web/src/app/new-company/page.tsx
+++ b/web/src/app/new-company/page.tsx
@@ -4,14 +4,23 @@ import FormTitle from "../components/form-title";
 import NewCompanyForm, {
     NewCompanyFormSchema,
 } from "./components/new-company-form";
-import { redirect } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import getSession from "../utis/get-session";
+import { jwtDecode } from "jwt-decode";
 
 export default async function NewCompany() {
     const session = getSession();
 
     if (!session) {
         return redirect("/login");
+    }
+
+    const decoded = jwtDecode(session) as {
+        level: string;
+    };
+
+    if (decoded.level === "USER" || decoded.level === "ADMIN") {
+        return notFound();
     }
 
     async function createCompany(data: NewCompanyFormSchema) {


### PR DESCRIPTION
# TELA NOVA EMPRESA APARECE SOMENTE PARA NÍVEL SUDO

## Qual problema esse pull request resolve?
Antes a tela era exibida para todos os níveis de usuários. Agora, foi ajustado para que usuário com nível SUDO possam visualiza-lá. Caso ADMIN ou USER tente acessar a página, responderá a página 404 (Not found). Além disso, foram implementadas autenticação e segurança no backend, que anteriormente estavam ausentes ao criar uma nova empresa.


## Como o seu código resolve esse problema?
- Usa decodificação da sessão para ver o nível de usuário para obter permissão de visualizar a tela (Somente SUDO). Usuários com nível ADMIN ou USER são redirecionados para a página 404 (Not Found).
- Adiciona o token e a chave secreta na rota `create-company.ts`, garantindo que apenas usuários SUDO possam criar uma nova empresa.


## Quais os passos para testar essa feature/bug?
- Faça atualização da sua main local no terminal: `npm i`

Print de teste:
SUDO criou uma nova empresa que é o Id 12:

![image](https://github.com/user-attachments/assets/898c15da-057b-4164-839f-790568644664)

ADMIN/USER: 

![Captura de tela 2024-11-05 115031](https://github.com/user-attachments/assets/b93c841d-d0c4-4325-a03d-36b703bde02c)
