### PR TITLE
Fix resource list display logic for empty state

### DIFF
--- a/web/src/app/components/empty-resources-list.tsx
+++ b/web/src/app/components/empty-resources-list.tsx
@@ -1,0 +1,36 @@
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+import Scheduling from "../home/assets/scheduling.svg";
+import CompanyLogo from "./company-logo";
+import Salute from "./salute";
+
+export default function EmptyResourcesList() {
+    return (
+        <>
+            <header className="flex justify-between items-end px-6 py-12">
+                <CompanyLogo />
+                <Salute>{"Usuário"}</Salute>
+            </header>
+
+            <section>
+                <div className="w-full max-w-sm mx-auto text-wrap bg-slate-100 p-4 rounded-lg">
+                    <p className="text-gray-950 text-base font-semibold p-2">
+                        Ahh não! Você ainda não tem nenhum recurso para agendar.
+                    </p>
+                </div>
+
+                <div className="flex justify-center items-center p-6">
+                    <Scheduling />
+                </div>
+
+                <div className="flex justify-center items-center p-2">
+                    <Button className="px-8 py-6 text-sm font-bold">
+                        {/* TODO: Vai para tela de agendamento */}
+                        <Link href="">CRIAR PRIMEIRO AGENDAMENTO</Link>
+                    </Button>
+                </div>
+            </section>
+        </>
+    );
+}
+

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,13 +1,11 @@
-import { Button } from "@/components/ui/button";
 import { ResourceResponse, Resources } from "@/types/resources";
-import Link from "next/link";
 import { redirect } from "next/navigation";
 import BottomFloatingMenu from "./components/bottom-floating-menu";
 import CategoriesList from "./components/categories-list";
 import CompanyLogo from "./components/company-logo";
+import EmptyResourcesList from "./components/empty-resources-list";
 import ResourcesList from "./components/resources-list";
 import Salute from "./components/salute";
-import Scheduling from "./home/assets/scheduling.svg";
 import getSession from "./utis/get-session";
 
 function transformResources(resources: ResourceResponse) {
@@ -54,34 +52,7 @@ export default async function Home() {
     const resources = await getResources(session);
 
     if (resources.length === 0) {
-        return (
-            <>
-                <header className="flex justify-between items-end px-6 py-12">
-                    <CompanyLogo />
-                    <Salute>{"Usuário"}</Salute>
-                </header>
-
-                <section>
-                    <div className="w-full max-w-sm mx-auto text-wrap bg-slate-100 p-4 rounded-lg">
-                        <p className="text-gray-950 text-base font-semibold p-2">
-                            Ahh não! Você ainda não tem nenhum recurso para
-                            agendar.
-                        </p>
-                    </div>
-
-                    <div className="flex justify-center items-center p-6">
-                        <Scheduling />
-                    </div>
-
-                    <div className="flex justify-center items-center p-2">
-                        <Button className="px-8 py-6 text-sm font-bold">
-                            {/* TODO: Vai para tela de agendamento */}
-                            <Link href="">CRIAR PRIMEIRO AGENDAMENTO</Link>
-                        </Button>
-                    </div>
-                </section>
-            </>
-        );
+        return <EmptyResourcesList />;
     }
 
     const resourcesByCategory = getResourcesByCategory(resources);

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -52,6 +52,38 @@ export default async function Home() {
     }
 
     const resources = await getResources(session);
+
+    if (resources.length === 0) {
+        return (
+            <>
+                <header className="flex justify-between items-end px-6 py-12">
+                    <CompanyLogo />
+                    <Salute>{"Usuário"}</Salute>
+                </header>
+
+                <section>
+                    <div className="w-full max-w-sm mx-auto text-wrap bg-slate-100 p-4 rounded-lg">
+                        <p className="text-gray-950 text-base font-semibold p-2">
+                            Ahh não! Você ainda não tem nenhum recurso para
+                            agendar.
+                        </p>
+                    </div>
+
+                    <div className="flex justify-center items-center p-6">
+                        <Scheduling />
+                    </div>
+
+                    <div className="flex justify-center items-center p-2">
+                        <Button className="px-8 py-6 text-sm font-bold">
+                            {/* TODO: Vai para tela de agendamento */}
+                            <Link href="">CRIAR PRIMEIRO AGENDAMENTO</Link>
+                        </Button>
+                    </div>
+                </section>
+            </>
+        );
+    }
+
     const resourcesByCategory = getResourcesByCategory(resources);
     const categoriesList = Object.keys(resourcesByCategory);
 
@@ -61,25 +93,6 @@ export default async function Home() {
                 <CompanyLogo />
                 <Salute>{"Usuário"}</Salute>
             </header>
-
-            <section>
-                <div className="w-full max-w-sm mx-auto text-wrap bg-slate-100 p-4 rounded-lg">
-                    <p className="text-gray-950 text-base font-semibold p-2">
-                        Ahh não! Você ainda não tem nenhum recurso para agendar.
-                    </p>
-                </div>
-
-                <div className="flex justify-center items-center p-6">
-                    <Scheduling />
-                </div>
-
-                <div className="flex justify-center items-center p-2">
-                    <Button className="px-8 py-6 text-sm font-bold">
-                        {/* TODO: Vai para tela de agendamento */}
-                        <Link href="">CRIAR PRIMEIRO AGENDAMENTO</Link>
-                    </Button>
-                </div>
-            </section>
 
             <section className="flex flex-col gap-6 pb-28">
                 <CategoriesList list={categoriesList} />
@@ -99,3 +112,4 @@ export default async function Home() {
         </>
     );
 }
+


### PR DESCRIPTION
# Corrigindo a lógica de exibição da lista de recursos para estado vazio

## Qual problema esse pull request resolve?
Corrige o problema onde a mensagem de "nenhum recurso disponível" aparecia mesmo quando já havia recursos cadastrados.

## Como o seu código resolve esse problema?
Foi adicionado um if que verifica se existem recursos antes de exibir a mensagem de "sem recursos". Se não houver nenhum recurso, a mensagem é mostrada. Caso contrário, ele exibe os recursos organizados por categorias.

## Quais os passos para testar essa feature/bug?
Basta acessar a aplicação com um perfil que não tem nenhum recurso cadastrado e depois acessar com um perfil que já tem recursos cadastrados.

Perfil sem recursos:
![Captura de tela 2024-11-28 143528](https://github.com/user-attachments/assets/774244df-441d-436d-933a-15d5982d63c3)

Perfil com recursos:
![Captura de tela 2024-11-28 143430](https://github.com/user-attachments/assets/101056a9-5de0-474a-b069-9fa5c053f467)

