### PR TITLE
Melhoria no uso de valores adicionados via middleware à request

### DIFF
--- a/api/src/http/middlewares/admin-route.ts
+++ b/api/src/http/middlewares/admin-route.ts
@@ -2,19 +2,14 @@ import { Level } from "@prisma/client";
 import { FastifyReply } from "fastify";
 import httpCodes from "../routes/utils/http-codes";
 import { LoggedRequest } from "./types/request";
+import { userIdentifiedRequest } from "./validator/requests";
 
 export function adminRoute(
     request: LoggedRequest,
     reply: FastifyReply,
     next: (err?: Error) => void,
 ) {
-    const { profile } = request;
-
-    if (!profile) {
-        return reply.status(httpCodes.UNAUTHORIZED).send({
-            message: "Perfil logado inválido ",
-        });
-    }
+    const { profile } = userIdentifiedRequest.parse(request);
 
     if (profile.level === Level.USER) {
         return reply.status(httpCodes.UNAUTHORIZED).send({

--- a/api/src/http/middlewares/find-logged-user.ts
+++ b/api/src/http/middlewares/find-logged-user.ts
@@ -2,18 +2,13 @@ import { FastifyReply } from "fastify";
 import profileRepository from "../../repositories/profiles";
 import httpCodes from "../routes/utils/http-codes";
 import { LoggedRequest } from "./types/request";
+import { authenticatedRequest } from "./validator/requests";
 
 export async function findLoggedUser(
     request: LoggedRequest,
     reply: FastifyReply,
 ) {
-    const { userId } = request;
-
-    if (!userId) {
-        return reply.status(httpCodes.UNAUTHORIZED).send({
-            message: "Faltando token de autenticação",
-        });
-    }
+    const { userId } = authenticatedRequest.parse(request);
 
     const profile = await profileRepository.findById(userId);
 
@@ -31,4 +26,3 @@ export async function findLoggedUser(
 
     request.profile = profile;
 }
-

--- a/api/src/http/middlewares/refresh-token.ts
+++ b/api/src/http/middlewares/refresh-token.ts
@@ -1,21 +1,18 @@
+import { FastifyReply } from "fastify";
 import { sign } from "jsonwebtoken";
 import { getJwtSecret } from "../routes/utils/get-jwt-secret";
 import httpCodes from "../routes/utils/http-codes";
 import { LoggedRequest } from "./types/request";
-import { FastifyReply } from "fastify";
+import { userIdentifiedRequest } from "./validator/requests";
+
+const _24_HOURS = 60 * 60 * 24 * 1000;
 
 export function refreshToken(
     request: LoggedRequest,
     reply: FastifyReply,
     next: (err?: Error) => void,
 ) {
-    const { profile } = request;
-
-    if (!profile) {
-        return reply
-            .status(httpCodes.UNAUTHORIZED)
-            .send({ message: "Perfil logado inválido!" });
-    }
+    const { profile } = userIdentifiedRequest.parse(request);
 
     const { password, ...profileWithoutPassword } = profile;
 
@@ -33,7 +30,7 @@ export function refreshToken(
         {
             ...profileWithoutPassword,
             iat: Date.now(),
-            exp: Date.now() + 60 * 60 * 24 * 1000,
+            exp: Date.now() + _24_HOURS,
         },
         secretKey,
     );

--- a/api/src/http/middlewares/sudo-route.ts
+++ b/api/src/http/middlewares/sudo-route.ts
@@ -2,19 +2,14 @@ import { Level } from "@prisma/client";
 import { FastifyReply } from "fastify";
 import httpCodes from "../routes/utils/http-codes";
 import { LoggedRequest } from "./types/request";
+import { userIdentifiedRequest } from "./validator/requests";
 
 export function sudoRoute(
     request: LoggedRequest,
     reply: FastifyReply,
     next: (err?: Error) => void,
 ) {
-    const { profile } = request;
-
-    if (!profile) {
-        return reply.status(httpCodes.UNAUTHORIZED).send({
-            message: "Perfil logado inválido ",
-        });
-    }
+    const { profile } = userIdentifiedRequest.parse(request);
 
     if (profile.level !== Level.SUDO) {
         return reply.status(httpCodes.UNAUTHORIZED).send({

--- a/api/src/http/middlewares/validator/requests.ts
+++ b/api/src/http/middlewares/validator/requests.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+export const authenticatedRequest = z.object({
+    userId: z.number(),
+});
+
+export const userIdentifiedRequest = authenticatedRequest.extend({
+    profile: z.object({
+        id: z.number(),
+        name: z.string(),
+        isActive: z.boolean(),
+        occupation: z.string().nullable(),
+        email: z.string(),
+        password: z.string(),
+        level: z.string(),
+        createdAt: z.date(),
+        updatedAt: z.date(),
+        companyId: z.number(),
+        firstLogin: z.boolean(),
+    }),
+});
+
+export const refreshedTokenRequest = userIdentifiedRequest.extend({
+    refreshedToken: z.string(),
+});

--- a/api/src/http/routes/get-categories.ts
+++ b/api/src/http/routes/get-categories.ts
@@ -3,8 +3,8 @@ import categoriesRepository from "../../repositories/categories";
 import { findLoggedUser } from "../middlewares/find-logged-user";
 import { refreshToken } from "../middlewares/refresh-token";
 import { LoggedRequest } from "../middlewares/types/request";
+import { refreshedTokenRequest } from "../middlewares/validator/requests";
 import { verifyToken } from "../middlewares/verify-token";
-import httpCodes from "./utils/http-codes";
 
 export async function getCategories(server: FastifyInstance) {
     server.get(
@@ -13,13 +13,8 @@ export async function getCategories(server: FastifyInstance) {
             preHandler: [verifyToken, findLoggedUser, refreshToken],
         },
         async (request: LoggedRequest, reply) => {
-            const { profile, refreshedToken } = request;
-
-            if (!profile) {
-                return reply.status(httpCodes.UNAUTHORIZED).send({
-                    message: "Perfil logado inválido ",
-                });
-            }
+            const { profile, refreshedToken } =
+                refreshedTokenRequest.parse(request);
 
             const categories = await categoriesRepository.findAll(
                 profile.companyId,


### PR DESCRIPTION
# Middlewares mais simples

## Qual problema esse pull request resolve?
A gente teve um problema com uso de valores adicionados ao middleware por conta da impossibilidade de informar sempre que as requests podiam possuir determinados valores.

Por cant disso, nosso código estava cheio de ifs desnecessários, pois o middleware garantiria que o código só atingiria aquele bloco caso desse tudo certo nas checagens antecedentes. Porém como tudo era feito em arquivos separados, o typescript não tinha condição de garantir essas checagens.


## Como o seu código resolve esse problema?
Esse PR faz uso do zod para simplificar a extração de valores da request. Fazendo um parse da request dentro de um schema, é possível extrair os valores já tipados. Caso alguma extração falhe, a api responderá com um 500.


## Quais os passos para testar essa feature/bug?
Faça uma requisição ao get-categories e vc deve ver um agrupamento de dados junto de um token atualizado.
