### PR TITLE
Buscar todos os agendamentos 

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -11,6 +11,7 @@
             "dependencies": {
                 "@prisma/client": "^5.10.2",
                 "bcrypt": "^5.1.1",
+                "date-fns": "^4.1.0",
                 "fastify": "^4.26.1",
                 "jsonwebtoken": "^9.0.2",
                 "zod": "^3.22.4"
@@ -957,6 +958,15 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/date-fns": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+            "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/kossnocorp"
             }
         },
         "node_modules/debug": {

--- a/api/package.json
+++ b/api/package.json
@@ -28,6 +28,7 @@
     "dependencies": {
         "@prisma/client": "^5.10.2",
         "bcrypt": "^5.1.1",
+        "date-fns": "^4.1.0",
         "fastify": "^4.26.1",
         "jsonwebtoken": "^9.0.2",
         "zod": "^3.22.4"

--- a/api/src/http/controllers/appointment.ts
+++ b/api/src/http/controllers/appointment.ts
@@ -3,7 +3,10 @@ import {
     appointmentsService,
     AppointmentsServiceType,
 } from "@services/appointments";
-import { findAppointmentSchema } from "@validators/appointments";
+import {
+    findAppointmentSchema,
+    findByDaySchema,
+} from "@validators/appointments";
 import { validate } from "@validators/validate";
 import { FastifyReply, FastifyRequest } from "fastify";
 import { CatchErrors } from "./utils/catch-errors";
@@ -15,6 +18,7 @@ class AppointmentsController {
         // Precisamos vincular o objeto "this" da função, pois a função "find"
         // é usada como callback no arquivo de rotas
         this.find = this.find.bind(this);
+        this.findByDay = this.findByDay.bind(this);
     }
 
     // Automaticamente captura e trata erros que podem acontecer a partir
@@ -33,6 +37,15 @@ class AppointmentsController {
         const appointment = await this.appointmentsService.find(id);
 
         // Devolvemos uma resposta http com resultado encontrado
+        return reply.status(SUCCESS).send({ appointment });
+    }
+
+    @CatchErrors()
+    async findByDay(request: FastifyRequest, reply: FastifyReply) {
+        const { startsAt } = validate(request.params, findByDaySchema);
+
+        const appointment = await this.appointmentsService.findByDay(startsAt);
+
         return reply.status(SUCCESS).send({ appointment });
     }
 }

--- a/api/src/http/routes/appointments/index.ts
+++ b/api/src/http/routes/appointments/index.ts
@@ -10,6 +10,12 @@ export function appointments(
     // Essa rota responde a /appointments/1, por exemplo.
     // Por enquanto não usa middlewares e executa a função find no appointments controller
     server.get("/:id", { preHandler: [] }, appointmentsController.find);
+    // Essa rota responde a /appointments/by-day/2025-04-16, por exemplo.
+    server.get(
+        "/by-day/:startsAt",
+        { preHandler: [] },
+        appointmentsController.findByDay,
+    );
 
     done();
 }

--- a/api/src/repositories/appointments.ts
+++ b/api/src/repositories/appointments.ts
@@ -9,26 +9,20 @@ class AppointmentsRepository {
 
     // Encontra um appointment através de uma data especifica (day)
     async findByDay(startsAt: Date | string) {
-        // Busca o início do dia.
-        const startOfDay = new Date(startsAt);
-        // Usa getDate para voltar um dia (Exemplo: 16 - 1 = 15, a data é 15)
-        startOfDay.setDate(startOfDay.getDate() - 1);
-        // Define o horário para o inicio do dia (Começa à meia-noite)
-        startOfDay.setHours(0, 0, 0, 0);
+        const startOfDay = new Date(startsAt); // Busca o início do dia.
+        startOfDay.setDate(startOfDay.getDate() - 1); // Volta um dia (Exemplo: 16 - 1 = 15, a data é 15)
+        startOfDay.setHours(0, 0, 0, 0); // Define o inicio do dia (Meia-noite)
 
-        // Busca o início do próximo dia.
-        const endOfDay = new Date(startsAt);
-        // Usa o getDate para avançar um dia (Exemplo: 16 + 1 = 17, a data é 17)
-        endOfDay.setDate(endOfDay.getDate() + 1);
-        // Define o horário para o início do próximo do dia (Antes de meia-noite).
-        endOfDay.setHours(0, 0, 0, 0);
+        const endOfDay = new Date(startsAt); // Busca o início do próximo dia.
+        endOfDay.setDate(endOfDay.getDate() + 1); //Avançar um dia (Exemplo: 16 + 1 = 17, a data é 17).
+        endOfDay.setHours(0, 0, 0, 0); // Define o início do próximo o dia (Antes de meia-noite).
 
         //Busca no banco de dados o dia desejado
         const appointments = await prisma.appointment.findMany({
             where: {
                 startsAt: {
-                    gte: startOfDay, // O gte(>=), pega o dia, por exemplo, >= 16/04/2025 00:00:00.
-                    lt: endOfDay, // O lt(<), pega antes do próximo dia, por exemplo, < 17/04/2025 00:00:00.
+                    gte: startOfDay, // O gte(>=), pega o dia (>= 16/04/2025 00:00:00).
+                    lt: endOfDay, // O lt(<), pega antes do próximo dia (< 17/04/2025 00:00:00).
                 },
             },
         });

--- a/api/src/repositories/appointments.ts
+++ b/api/src/repositories/appointments.ts
@@ -1,8 +1,39 @@
+import { prisma } from "@lib/prisma";
+
 class AppointmentsRepository {
     // Encontra um appointment através do seu id
     async find(id: number) {
         //TODO: fazer a busca em banco de dados quando houver dados
         return `From repository id: ${id}`;
+    }
+
+    // Encontra um appointment através de uma data especifica (day)
+    async findByDay(startsAt: Date | string) {
+        // Busca o início do dia.
+        const startOfDay = new Date(startsAt);
+        // Usa getDate para voltar um dia (Exemplo: 16 - 1 = 15, a data é 15)
+        startOfDay.setDate(startOfDay.getDate() - 1);
+        // Define o horário para o inicio do dia (Começa à meia-noite)
+        startOfDay.setHours(0, 0, 0, 0);
+
+        // Busca o início do próximo dia.
+        const endOfDay = new Date(startsAt);
+        // Usa o getDate para avançar um dia (Exemplo: 16 + 1 = 17, a data é 17)
+        endOfDay.setDate(endOfDay.getDate() + 1);
+        // Define o horário para o início do próximo do dia (Antes de meia-noite).
+        endOfDay.setHours(0, 0, 0, 0);
+
+        //Busca no banco de dados o dia desejado
+        const appointments = await prisma.appointment.findMany({
+            where: {
+                startsAt: {
+                    gte: startOfDay, // O gte(>=), pega o dia, por exemplo, >= 16/04/2025 00:00:00.
+                    lt: endOfDay, // O lt(<), pega antes do próximo dia, por exemplo, < 17/04/2025 00:00:00.
+                },
+            },
+        });
+
+        return appointments;
     }
 }
 

--- a/api/src/repositories/appointments.ts
+++ b/api/src/repositories/appointments.ts
@@ -8,10 +8,10 @@ class AppointmentsRepository {
         return `From repository id: ${id}`;
     }
 
-    // Encontra um appointment através de uma data especifica (day)
+    // Encontra um appointment através de uma data especifica
     async findByDay(startsAt: Date) {
-        const startOfDay = new Date(startsAt); // Pega o início da data informada
-        const endOfDay = addDays(startOfDay, 1); // Obtem o final do dia (Amanhã)
+        const startOfDay = new Date(startsAt); // Recebe o início do dia da data informada
+        const endOfDay = addDays(startOfDay, 1); // Recebe o início do dia seguinte
 
         //Busca no banco de dados o dia desejado
         const appointments = await prisma.appointment.findMany({

--- a/api/src/repositories/appointments.ts
+++ b/api/src/repositories/appointments.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@lib/prisma";
-import { addDays } from "date-fns";
+import { addDays, parseISO } from "date-fns";
 
 class AppointmentsRepository {
     // Encontra um appointment através do seu id
@@ -11,14 +11,12 @@ class AppointmentsRepository {
     // Encontra um appointment através de uma data especifica
     async findByDay(startsAt: Date) {
         const startOfDay = new Date(startsAt); // Recebe o início do dia da data informada
-        const endOfDay = addDays(startOfDay, 1); // Recebe o início do dia seguinte
 
         //Busca no banco de dados o dia desejado
         const appointments = await prisma.appointment.findMany({
             where: {
                 startsAt: {
-                    gte: startOfDay, // O gte(>=), início do dia (>= 2025-04-16).
-                    lt: endOfDay, // O lt(<), início do dia seguinte (< 2025/04/17).
+                    equals: startOfDay,
                 },
             },
         });

--- a/api/src/repositories/appointments.ts
+++ b/api/src/repositories/appointments.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@lib/prisma";
-import { addDays, subDays } from "date-fns";
+import { addDays } from "date-fns";
 
 class AppointmentsRepository {
     // Encontra um appointment através do seu id

--- a/api/src/repositories/appointments.ts
+++ b/api/src/repositories/appointments.ts
@@ -1,4 +1,5 @@
 import { prisma } from "@lib/prisma";
+import { addDays, subDays } from "date-fns";
 
 class AppointmentsRepository {
     // Encontra um appointment através do seu id
@@ -8,21 +9,16 @@ class AppointmentsRepository {
     }
 
     // Encontra um appointment através de uma data especifica (day)
-    async findByDay(startsAt: Date | string) {
-        const startOfDay = new Date(startsAt); // Busca o início do dia.
-        startOfDay.setDate(startOfDay.getDate() - 1); // Volta um dia (Exemplo: 16 - 1 = 15, a data é 15)
-        startOfDay.setHours(0, 0, 0, 0); // Define o inicio do dia (Meia-noite)
-
-        const endOfDay = new Date(startsAt); // Busca o início do próximo dia.
-        endOfDay.setDate(endOfDay.getDate() + 1); //Avançar um dia (Exemplo: 16 + 1 = 17, a data é 17).
-        endOfDay.setHours(0, 0, 0, 0); // Define o início do próximo o dia (Antes de meia-noite).
+    async findByDay(startsAt: Date) {
+        const startOfDay = new Date(startsAt); // Pega o início da data informada
+        const endOfDay = addDays(startOfDay, 1); // Obtem o final do dia (Amanhã)
 
         //Busca no banco de dados o dia desejado
         const appointments = await prisma.appointment.findMany({
             where: {
                 startsAt: {
-                    gte: startOfDay, // O gte(>=), pega o dia (>= 16/04/2025 00:00:00).
-                    lt: endOfDay, // O lt(<), pega antes do próximo dia (< 17/04/2025 00:00:00).
+                    gte: startOfDay, // O gte(>=), início do dia (>= 2025-04-16).
+                    lt: endOfDay, // O lt(<), início do dia seguinte (< 2025/04/17).
                 },
             },
         });

--- a/api/src/services/appointments.ts
+++ b/api/src/services/appointments.ts
@@ -15,6 +15,13 @@ class AppointmentsService {
 
         return appointment;
     }
+
+    async findByDay(startsAt: Date) {
+        const appointment =
+            await this.appointmentsRepository.findByDay(startsAt);
+
+        return appointment;
+    }
 }
 
 export const appointmentsService = new AppointmentsService(

--- a/api/src/validators/appointments.ts
+++ b/api/src/validators/appointments.ts
@@ -7,3 +7,11 @@ export const findAppointmentSchema = z.object({
         invalid_type_error: "Id do agendamento tem que ser um número",
     }),
 });
+
+// Para validar a data (startsAt) usada na busca por agendamentos em um dia específico.
+export const findByDaySchema = z.object({
+    startsAt: z.coerce.date({
+        required_error: "Data de agendamento é obrigatória!",
+        invalid_type_error: "A data de agendamento precisa ser válida",
+    }),
+});


### PR DESCRIPTION
BUSCAR TODOS OS AGENDAMENTOS BASEADO EM UM DIA

## Qual problema esse pull request resolve?
Foi criado uma requisição para buscar todos os agendamentos de um determinado dia, sem utilização de filtro.

## Como o seu código resolve esse problema?
Primeiramente, utilizei a biblioteca `date-fns`, que torna o código mais semântico, limpo e com menor risco de erros.
No repositório, foi adicionada a função `findByDay`, responsável por buscar os agendamentos de um determinado dia.
Essa busca é feita através do Prisma, utilizando o campo `startsAt`, conforme definido na tabela appointment.
Além disso, foram implementados os ajustes necessários nas partes de services, controllers, validators e routes, para que a requisição de busca funcione corretamente.


## Quais os passos para testar essa feature/bug?
- Atualize a branch `main` e execute `npm i` na API para instalar as dependências do `date-fns` localmente.
- Para realizar um teste, abra o **Postman** (ou outra ferramenta de sua preferência), crie uma requisição do tipo GET e insira o endereço http://localhost:8080/appointments/by-day/digite-uma-data-aqui.
- O resultado será exibido como `"appointment": [ ]` (vazio).

Teste realizado:
![Captura de tela 2025-04-16 195839](https://github.com/user-attachments/assets/d8e2d49f-2b3b-4282-aad9-33b8cec91005)

