### PR TITLE
Create route POST to create appointments

### DIFF
--- a/api/src/http/controllers/appointment.ts
+++ b/api/src/http/controllers/appointment.ts
@@ -3,7 +3,10 @@ import {
     appointmentsService,
     AppointmentsServiceType,
 } from "@services/appointments";
-import { findAppointmentSchema } from "@validators/appointments";
+import {
+    createAppointmentSchema,
+    findAppointmentSchema,
+} from "@validators/appointments";
 import { validate } from "@validators/validate";
 import { FastifyReply, FastifyRequest } from "fastify";
 import { CatchErrors } from "./utils/catch-errors";
@@ -15,6 +18,7 @@ class AppointmentsController {
         // Precisamos vincular o objeto "this" da função, pois a função "find"
         // é usada como callback no arquivo de rotas
         this.find = this.find.bind(this);
+        this.create = this.create.bind(this);
     }
 
     // Automaticamente captura e trata erros que podem acontecer a partir
@@ -35,8 +39,18 @@ class AppointmentsController {
         // Devolvemos uma resposta http com resultado encontrado
         return reply.status(SUCCESS).send({ appointment });
     }
+
+    @CatchErrors()
+    async create(request: FastifyRequest, reply: FastifyReply) {
+        const data = validate(request.body, createAppointmentSchema);
+
+        const appointment = await this.appointmentsService.create(data);
+
+        return reply.status(201).send({ appointment });
+    }
 }
 
 export const appointmentsController = new AppointmentsController(
     appointmentsService,
 );
+

--- a/api/src/http/routes/appointments/index.ts
+++ b/api/src/http/routes/appointments/index.ts
@@ -10,6 +10,8 @@ export function appointments(
     // Essa rota responde a /appointments/1, por exemplo.
     // Por enquanto não usa middlewares e executa a função find no appointments controller
     server.get("/:id", { preHandler: [] }, appointmentsController.find);
+    server.post("/", { preHandler: [] }, appointmentsController.create);
 
     done();
 }
+

--- a/api/src/repositories/appointments.ts
+++ b/api/src/repositories/appointments.ts
@@ -1,11 +1,24 @@
+import { prisma } from "@lib/prisma";
+
 class AppointmentsRepository {
     // Encontra um appointment através do seu id
     async find(id: number) {
         //TODO: fazer a busca em banco de dados quando houver dados
         return `From repository id: ${id}`;
     }
+
+    async create(data: {
+        name: string;
+        description: string;
+        startsAt: Date;
+        endsAt: Date;
+    }) {
+        const appointment = await prisma.appointment.create({ data });
+        return appointment;
+    }
 }
 
 export const appointmentsRepository = new AppointmentsRepository();
 
 export type AppointmentsRepositoryType = typeof appointmentsRepository;
+

--- a/api/src/services/appointments.ts
+++ b/api/src/services/appointments.ts
@@ -31,5 +31,5 @@ export const appointmentsService = new AppointmentsService(
     appointmentsRepository,
 );
 
-export type AppointmentsServiceType = AppointmentsService;
+export type AppointmentsServiceType = typeof appointmentsService;
 

--- a/api/src/services/appointments.ts
+++ b/api/src/services/appointments.ts
@@ -15,10 +15,21 @@ class AppointmentsService {
 
         return appointment;
     }
+
+    async create(data: {
+        name: string;
+        description: string;
+        startsAt: Date;
+        endsAt: Date;
+    }) {
+        const appointment = await this.appointmentsRepository.create(data);
+        return appointment;
+    }
 }
 
 export const appointmentsService = new AppointmentsService(
     appointmentsRepository,
 );
 
-export type AppointmentsServiceType = typeof appointmentsService;
+export type AppointmentsServiceType = AppointmentsService;
+

--- a/api/src/validators/appointments.ts
+++ b/api/src/validators/appointments.ts
@@ -7,3 +7,21 @@ export const findAppointmentSchema = z.object({
         invalid_type_error: "Id do agendamento tem que ser um número",
     }),
 });
+
+export const createAppointmentSchema = z.object({
+    name: z.string({
+        required_error: "O nome é obrigatório",
+    }),
+    description: z.string({
+        required_error: "A descrição é obrigatória",
+    }),
+    startsAt: z.coerce.date({
+        required_error: "A data de início é obrigatória",
+        invalid_type_error: "A data de início deve ser válida",
+    }),
+    endsAt: z.coerce.date({
+        required_error: "A data de término é obrigatória",
+        invalid_type_error: "A data de término deve ser válida",
+    }),
+});
+


### PR DESCRIPTION
# Cria uma rota POST para criar agendamentos

## Qual problema esse pull request resolve?
Adiciona a funcionalidade de criação de agendamentos via rota POST /appointments.


## Como o seu código resolve esse problema?
Implementa uma rota `POST `que valida os dados com Zod e salva no banco com o Prisma. A lógica foi separada em controller, service e repository. Também foram adicionados tratamentos de erro para garantir respostas claras em caso de falhas.


## Quais os passos para testar essa feature/bug?

- Rodar a aplicação com `marquei run`
- Acessar o postman ou alguma ferramenta similar e enviar uma requisição POST para `http://localhost:8080/appointments` com um corpo JSON como este:

![Captura de tela 2025-04-25 112614](https://github.com/user-attachments/assets/f1531783-07f9-40f7-b360-645b4ff3c93e)

- Verificar se a resposta retorna status 201 e se o registro foi salvo corretamente usando o prisma studio.



